### PR TITLE
Fix: Remove value from CVE Description primary key

### DIFF
--- a/greenbone/scap/cve/manager.py
+++ b/greenbone/scap/cve/manager.py
@@ -286,7 +286,6 @@ class CVEManager(AsyncContextManager):
                     index_elements=[
                         CVEDescriptionModel.cve_id,
                         CVEDescriptionModel.lang,
-                        CVEDescriptionModel.value,
                     ],
                     set_=dict(
                         cve_id=statement.excluded.cve_id,

--- a/greenbone/scap/cve/models.py
+++ b/greenbone/scap/cve/models.py
@@ -126,7 +126,7 @@ class CVEDescriptionModel(Base):
 
     cve_id: Mapped[cve_fk] = mapped_column(primary_key=True)
     lang: Mapped[str] = mapped_column(primary_key=True)
-    value: Mapped[str] = mapped_column(primary_key=True)
+    value: Mapped[str]
 
     cve: Mapped[CVEModel] = relationship(back_populates="descriptions")
 


### PR DESCRIPTION

## What

Remove value from CVE Description primary key

## Why

Fix the db model of the CVE Description. There should only be one description per CVE and language. Currently inserting a description may fail because the value is too long for the primary key btree index.


