### PR TITLE
Fix: uses ruff check

### DIFF
--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -21,7 +21,7 @@ jobs:
         uses: greenbone/actions/lint-python@v3
         with:
           packages: greenbone
-          linter: ruff
+          linter: ruff check
           python-version: ${{ matrix.python-version }}
 
   test:


### PR DESCRIPTION
<## What

Fix: Use ruff check as linter

## Why

Using `ruff` is deprecated ...

## References

[DEVOPS-1093](https://jira.greenbone.net/browse/DEVOPS-1093)

