### PR TITLE
Fix: Update outdated settings in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,8 @@ version-module-file = "greenbone/scap/__version__.py"
 [tool.ruff]
 line-length = 80
 target-version = "py39"
+
+[tool.ruff.lint]
 extend-select = ["I", "PLE", "PLW"]
 
 [tool.poetry.scripts]


### PR DESCRIPTION
## What
Adjust the settings for ruff in the `pyproject.toml`, to prevent the printing of:

```
warning: The top-level linter settings are deprecated in favour of their counterparts in the `lint` section. Please update the following options in `pyproject.toml`:
  - 'extend-select' -> 'lint.extend-select'
  - 'ignore' -> 'lint.ignore'
  - 'per-file-ignores' -> 'lint.per-file-ignores'
```
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why
Remove deprecation warning
<!-- Describe why are these changes necessary? -->

## References
DEVOPS-1116
<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


