### PR TITLE
Add: New CLI for downloading CPE match strings

### DIFF
--- a/greenbone/scap/cpe/cli/download.py
+++ b/greenbone/scap/cpe/cli/download.py
@@ -424,10 +424,14 @@ async def download(console: Console, error_console: Console) -> None:
             )
 
             if run_time_file:
+                if until:
+                    run_time = until
+                else:
+                    run_time = datetime.now()
                 # ensure directories exist
                 run_time_file.parent.mkdir(parents=True, exist_ok=True)
                 run_time_file.write_text(
-                    f"{until.isoformat()}\n",
+                    f"{run_time.isoformat()}\n",
                     encoding="utf8",  # type: ignore
                 )
                 console.log(f"Wrote run time to {run_time_file.absolute()}.")

--- a/greenbone/scap/cpe/cli/download.py
+++ b/greenbone/scap/cpe/cli/download.py
@@ -427,7 +427,8 @@ async def download(console: Console, error_console: Console) -> None:
                 # ensure directories exist
                 run_time_file.parent.mkdir(parents=True, exist_ok=True)
                 run_time_file.write_text(
-                    f"{until.isoformat()}\n", encoding="utf8"  # type: ignore
+                    f"{until.isoformat()}\n",
+                    encoding="utf8",  # type: ignore
                 )
                 console.log(f"Wrote run time to {run_time_file.absolute()}.")
 

--- a/greenbone/scap/cpe_match/__init__.py
+++ b/greenbone/scap/cpe_match/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2024 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later

--- a/greenbone/scap/cpe_match/cli/__init__.py
+++ b/greenbone/scap/cpe_match/cli/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2024 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later

--- a/greenbone/scap/cpe_match/cli/db_download.py
+++ b/greenbone/scap/cpe_match/cli/db_download.py
@@ -2,20 +2,19 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from argparse import Namespace, ArgumentParser
+from argparse import ArgumentParser, Namespace
 from typing import Sequence
 
 import shtab
 from rich.progress import Progress
 
-from greenbone.scap.cli import CLIRunner
-from greenbone.scap.cpe_match.cli.processor import CpeMatchProcessor
+from ...cli import CLIRunner
+from ...cpe_match.cli.processor import CpeMatchProcessor
 from ..producer.nvd_api import CpeMatchNvdApiProducer
 from ..worker.db import CpeMatchDatabaseWriteWorker
 
 
 def parse_args(args: Sequence[str] | None = None) -> Namespace:
-
     parser = ArgumentParser(
         description="Update a CPE match strings database from an API. "
         "Downloads CPE match string information from the NIST NVD REST API "
@@ -33,11 +32,9 @@ def parse_args(args: Sequence[str] | None = None) -> Namespace:
 
 
 async def download(console, error_console) -> None:
-
     args = parse_args()
 
     with Progress(console=console) as progress:
-
         producer = CpeMatchNvdApiProducer.from_args(
             args,
             console,

--- a/greenbone/scap/cpe_match/cli/db_download.py
+++ b/greenbone/scap/cpe_match/cli/db_download.py
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: 2024 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from argparse import Namespace, ArgumentParser
+from typing import Sequence
+
+import shtab
+from rich.progress import Progress
+
+from greenbone.scap.cli import CLIRunner
+from greenbone.scap.cpe_match.cli.processor import CpeMatchProcessor
+from ..producer.nvd_api import CpeMatchNvdApiProducer
+from ..worker.db import CpeMatchDatabaseWriteWorker
+
+
+def parse_args(args: Sequence[str] | None = None) -> Namespace:
+
+    parser = ArgumentParser(
+        description="Update a CPE match strings database from an API. "
+        "Downloads CPE match string information from the NIST NVD REST API "
+        "and stores it in a database."
+    )
+    shtab.add_argument_to(parser)
+
+    CpeMatchNvdApiProducer.add_args_to_parser(parser)
+
+    CpeMatchDatabaseWriteWorker.add_args_to_parser(parser)
+
+    CpeMatchProcessor.add_args_to_parser(parser)
+
+    return parser.parse_args(args)
+
+
+async def download(console, error_console) -> None:
+
+    args = parse_args()
+
+    with Progress(console=console) as progress:
+
+        producer = CpeMatchNvdApiProducer.from_args(
+            args,
+            console,
+            error_console,
+            progress,
+        )
+
+        worker = CpeMatchDatabaseWriteWorker.from_args(
+            args,
+            console,
+            error_console,
+            progress,
+        )
+
+        processor = CpeMatchProcessor.from_args(
+            args,
+            console,
+            error_console,
+            producer,
+            worker,
+        )
+
+        await processor.run()
+
+
+def main() -> None:
+    CLIRunner.run(download)
+
+
+if __name__ == "__main__":
+    main()

--- a/greenbone/scap/cpe_match/cli/json_download.py
+++ b/greenbone/scap/cpe_match/cli/json_download.py
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: 2024 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from argparse import Namespace, ArgumentParser
+from typing import Sequence
+
+import shtab
+from rich.progress import Progress
+
+from greenbone.scap.cli import CLIRunner
+from greenbone.scap.cpe_match.cli.processor import CpeMatchProcessor
+from ..producer.nvd_api import CpeMatchNvdApiProducer
+from ..worker.json import CpeMatchJsonWriteWorker
+
+
+def parse_args(args: Sequence[str] | None = None) -> Namespace:
+
+    parser = ArgumentParser(
+        description="Download and consolidate CPE match strings. "
+        "Downloads CPE match string information from the NIST NVD REST API "
+        "and consolidates it into a single JSON file."
+    )
+    shtab.add_argument_to(parser)
+
+    CpeMatchNvdApiProducer.add_args_to_parser(parser)
+
+    CpeMatchJsonWriteWorker.add_args_to_parser(parser)
+
+    CpeMatchProcessor.add_args_to_parser(parser)
+
+    return parser.parse_args(args)
+
+
+async def download(console, error_console) -> None:
+
+    args = parse_args()
+
+    with Progress(console=console) as progress:
+
+        producer = CpeMatchNvdApiProducer.from_args(
+            args,
+            console,
+            error_console,
+            progress,
+        )
+
+        worker = CpeMatchJsonWriteWorker.from_args(
+            args,
+            console,
+            error_console,
+            progress,
+        )
+
+        processor = CpeMatchProcessor.from_args(
+            args,
+            console,
+            error_console,
+            producer,
+            worker,
+        )
+
+        await processor.run()
+
+
+def main() -> None:
+    CLIRunner.run(download)
+
+
+if __name__ == "__main__":
+    main()

--- a/greenbone/scap/cpe_match/cli/json_download.py
+++ b/greenbone/scap/cpe_match/cli/json_download.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from argparse import Namespace, ArgumentParser
+from argparse import ArgumentParser, Namespace
 from typing import Sequence
 
 import shtab
@@ -10,12 +10,12 @@ from rich.progress import Progress
 
 from greenbone.scap.cli import CLIRunner
 from greenbone.scap.cpe_match.cli.processor import CpeMatchProcessor
+
 from ..producer.nvd_api import CpeMatchNvdApiProducer
 from ..worker.json import CpeMatchJsonWriteWorker
 
 
 def parse_args(args: Sequence[str] | None = None) -> Namespace:
-
     parser = ArgumentParser(
         description="Download and consolidate CPE match strings. "
         "Downloads CPE match string information from the NIST NVD REST API "
@@ -33,11 +33,9 @@ def parse_args(args: Sequence[str] | None = None) -> Namespace:
 
 
 async def download(console, error_console) -> None:
-
     args = parse_args()
 
     with Progress(console=console) as progress:
-
         producer = CpeMatchNvdApiProducer.from_args(
             args,
             console,

--- a/greenbone/scap/cpe_match/cli/processor.py
+++ b/greenbone/scap/cpe_match/cli/processor.py
@@ -10,7 +10,7 @@ from rich.console import Console
 from ...cli import DEFAULT_VERBOSITY
 from ...generic_cli.processor import ScapProcessor
 from ...generic_cli.producer.base import BaseScapProducer
-from ...generic_cli.queue import DEFAULT_QUEUE_SIZE, DEFAULT_CHUNK_SIZE
+from ...generic_cli.queue import DEFAULT_QUEUE_SIZE
 from ...generic_cli.worker.base import BaseScapWorker
 
 CPE_MATCH_TYPE_PLURAL = "CPE match strings"
@@ -18,7 +18,6 @@ CPE_MATCH_DEFAULT_CHUNK_SIZE = 500
 
 
 class CpeMatchProcessor(ScapProcessor[CPEMatchString]):
-
     item_type_plural = CPE_MATCH_TYPE_PLURAL
     arg_defaults = {
         "chunk_size": CPE_MATCH_DEFAULT_CHUNK_SIZE,

--- a/greenbone/scap/cpe_match/cli/processor.py
+++ b/greenbone/scap/cpe_match/cli/processor.py
@@ -18,8 +18,13 @@ CPE_MATCH_DEFAULT_CHUNK_SIZE = 500
 
 
 class CpeMatchProcessor(ScapProcessor[CPEMatchString]):
-    item_type_plural = CPE_MATCH_TYPE_PLURAL
-    arg_defaults = {
+    """
+    Class that handles a producer object generating CPE match strings
+    to be processed by a worker object.
+    """
+
+    _item_type_plural = CPE_MATCH_TYPE_PLURAL
+    _arg_defaults = {
         "chunk_size": CPE_MATCH_DEFAULT_CHUNK_SIZE,
         "queue_size": DEFAULT_QUEUE_SIZE,
         "verbose": DEFAULT_VERBOSITY,
@@ -33,6 +38,19 @@ class CpeMatchProcessor(ScapProcessor[CPEMatchString]):
         producer: BaseScapProducer,
         worker: BaseScapWorker,
     ) -> "CpeMatchProcessor":
+        """
+        Create a new `CPEMatchNvdApiProducer` with parameters from
+         the given command line args gathered by an `ArgumentParser`.
+
+        Args:
+            args: Command line arguments to use
+            console: Console for standard output.
+            error_console: Console for error output.
+            producer: The producer generating the CPE match strings.
+            worker: The worker processing the CPE match strings.
+        Returns:
+            The new `CpeMatchProcessor`.
+        """
         return CpeMatchProcessor(
             console,
             error_console,
@@ -54,6 +72,18 @@ class CpeMatchProcessor(ScapProcessor[CPEMatchString]):
         chunk_size: int | None = None,
         verbose: int | None = None,
     ):
+        """
+        Constructor for a new CPE match string processor.
+
+        Args:
+            console: Console for standard output.
+            error_console: Console for error output.
+            producer: The producer generating the CPE match strings.
+            worker: The worker processing the CPE match strings.
+            queue_size: The number of chunks allowed in the queue.
+            chunk_size: The expected maximum number of CPE match strings per chunk.
+            verbose: Verbosity level of log messages.
+        """
         super().__init__(
             console,
             error_console,

--- a/greenbone/scap/cpe_match/cli/processor.py
+++ b/greenbone/scap/cpe_match/cli/processor.py
@@ -1,0 +1,66 @@
+# SPDX-FileCopyrightText: 2024 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from argparse import Namespace
+
+from pontos.nvd.models.cpe_match_string import CPEMatchString
+from rich.console import Console
+
+from ...cli import DEFAULT_VERBOSITY
+from ...generic_cli.processor import ScapProcessor
+from ...generic_cli.producer.base import BaseScapProducer
+from ...generic_cli.queue import DEFAULT_QUEUE_SIZE, DEFAULT_CHUNK_SIZE
+from ...generic_cli.worker.base import BaseScapWorker
+
+CPE_MATCH_TYPE_PLURAL = "CPE match strings"
+CPE_MATCH_DEFAULT_CHUNK_SIZE = 500
+
+
+class CpeMatchProcessor(ScapProcessor[CPEMatchString]):
+
+    item_type_plural = CPE_MATCH_TYPE_PLURAL
+    arg_defaults = {
+        "chunk_size": CPE_MATCH_DEFAULT_CHUNK_SIZE,
+        "queue_size": DEFAULT_QUEUE_SIZE,
+        "verbose": DEFAULT_VERBOSITY,
+    }
+
+    @staticmethod
+    def from_args(
+        args: Namespace,
+        console: Console,
+        error_console: Console,
+        producer: BaseScapProducer,
+        worker: BaseScapWorker,
+    ) -> "CpeMatchProcessor":
+        return CpeMatchProcessor(
+            console,
+            error_console,
+            producer,
+            worker,
+            queue_size=args.queue_size,
+            chunk_size=args.chunk_size,
+            verbose=args.verbose,
+        )
+
+    def __init__(
+        self,
+        console: Console,
+        error_console: Console,
+        producer: BaseScapProducer,
+        worker: BaseScapWorker,
+        *,
+        queue_size: int | None = None,
+        chunk_size: int | None = None,
+        verbose: int | None = None,
+    ):
+        super().__init__(
+            console,
+            error_console,
+            producer,
+            worker,
+            queue_size=queue_size,
+            chunk_size=chunk_size,
+            verbose=verbose,
+        )

--- a/greenbone/scap/cpe_match/db/manager.py
+++ b/greenbone/scap/cpe_match/db/manager.py
@@ -1,0 +1,261 @@
+# SPDX-FileCopyrightText: 2024 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from datetime import datetime
+from types import TracebackType
+from typing import AsyncContextManager, AsyncIterator, Self, Sequence
+
+from pontos.nvd.models.cpe_match_string import CPEMatchString
+from sqlalchemy import (
+    func,
+    select,
+)
+from sqlalchemy.ext.asyncio import AsyncConnection
+from sqlalchemy.orm import selectinload
+
+from greenbone.scap.db import Database
+
+from greenbone.scap.cpe_match.db.models import (
+    BaseDatabaseModel,
+    CPEMatchStringDatabaseModel,
+    CPEMatchDatabaseModel,
+)
+
+
+DEFAULT_THRESHOLD = 100
+DEFAULT_YIELD_PER = 100
+
+
+class CPEMatchStringDatabaseManager(AsyncContextManager):
+    def __init__(
+        self,
+        db: Database,
+        *,
+        insert_threshold: int = DEFAULT_THRESHOLD,
+        yield_per: int = DEFAULT_YIELD_PER,
+        update: bool = True,
+    ) -> None:
+        self._db = db
+        self._cpe_match_strings: list[CPEMatchString] = []
+        self._insert_threshold = insert_threshold
+        self._update = update
+        self._yield_per = yield_per
+
+    async def __aenter__(self) -> Self:
+        await self._db.init(BaseDatabaseModel.metadata.create_all)
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        _exc_value: BaseException | None,
+        _traceback: TracebackType | None,
+    ) -> None:
+        if not exc_type:
+            # not an error
+            await self.add_cpe_match_strings(self._cpe_match_strings)
+        return
+
+    async def add(self, match_string: CPEMatchString) -> None:
+        self._cpe_match_strings.append(match_string)
+
+        if len(self._cpe_match_strings) > self._insert_threshold:
+            await self.add_cpe_match_strings(self._cpe_match_strings)
+
+    async def add_cpe_match_strings(
+        self, match_strings: Sequence[CPEMatchString]
+    ) -> None:
+        if not match_strings:
+            return
+
+        statement = self._db.insert(CPEMatchStringDatabaseModel)
+        if self._update:
+            statement = statement.on_conflict_do_update(
+                index_elements=[CPEMatchStringDatabaseModel.match_criteria_id],
+                set_=dict(
+                    criteria=statement.excluded.criteria,
+                    status=statement.excluded.status,
+                    cpe_last_modified=statement.excluded.cpe_last_modified,
+                    created=statement.excluded.created,
+                    last_modified=statement.excluded.last_modified,
+                    version_start_including=statement.excluded.version_start_including,
+                    version_start_excluding=statement.excluded.version_start_excluding,
+                    version_end_including=statement.excluded.version_end_including,
+                    version_end_excluding=statement.excluded.version_end_excluding,
+                ),
+            )
+        else:
+            statement = statement.on_conflict_do_nothing()
+
+        async with self._db.transaction() as transaction:
+            await transaction.execute(
+                statement,
+                [
+                    dict(
+                        match_criteria_id=match_string.match_criteria_id,
+                        criteria=match_string.criteria,
+                        status=match_string.status,
+                        cpe_last_modified=match_string.cpe_last_modified,
+                        created=match_string.created,
+                        last_modified=match_string.last_modified,
+                        version_start_including=match_string.version_start_including,
+                        version_start_excluding=match_string.version_start_excluding,
+                        version_end_including=match_string.version_end_including,
+                        version_end_excluding=match_string.version_end_excluding,
+                    )
+                    for match_string in match_strings
+                ],
+            )
+            await self._insert_foreign_data(transaction, match_strings)
+
+        self._cpes = []
+
+    async def _insert_foreign_data(
+        self,
+        connection: AsyncConnection,
+        match_strings: Sequence[CPEMatchString],
+    ) -> None:
+        matches_data = [
+            dict(
+                match_criteria_id=match_string.match_criteria_id,
+                cpe_name=match.cpe_name,
+                cpe_name_id=match.cpe_name_id,
+            )
+            for match_string in match_strings
+            for match in match_string.matches
+        ]
+        if matches_data:
+            statement = self._db.insert(CPEMatchDatabaseModel)
+            if self._update:
+                statement = statement.on_conflict_do_update(
+                    index_elements=[
+                        CPEMatchDatabaseModel.match_criteria_id,
+                        CPEMatchDatabaseModel.cpe_name_id,
+                    ],
+                    set_=dict(
+                        match_criteria_id=statement.excluded.match_criteria_id,
+                        cpe_name=statement.excluded.cpe_name,
+                        cpe_name_id=statement.excluded.cpe_name_id,
+                    ),
+                )
+            else:
+                statement = statement.on_conflict_do_nothing()
+
+            await connection.execute(statement, matches_data)
+
+    async def find(
+        self,
+        *,
+        match_criteria_id: str | None = None,
+        limit: int | None = None,
+        index: int | None = None,
+        last_modification_start_date: datetime | None = None,
+        last_modification_end_date: datetime | None = None,
+        published_start_date: datetime | None = None,
+        published_end_date: datetime | None = None,
+    ) -> AsyncIterator[CPEMatchStringDatabaseModel]:
+        clauses = []
+
+        if match_criteria_id is not None:
+            clauses.append(
+                CPEMatchStringDatabaseModel.match_criteria_id
+                == match_criteria_id
+            )
+
+        if last_modification_start_date:
+            clauses.append(
+                CPEMatchStringDatabaseModel.last_modified
+                >= last_modification_start_date
+            )
+        if last_modification_end_date:
+            clauses.append(
+                CPEMatchStringDatabaseModel.last_modified
+                <= last_modification_end_date
+            )
+        if published_start_date:
+            clauses.append(
+                CPEMatchStringDatabaseModel.published >= published_start_date
+            )
+        if published_end_date:
+            clauses.append(
+                CPEMatchStringDatabaseModel.published <= published_end_date
+            )
+
+        statement = (
+            select(CPEMatchStringDatabaseModel)
+            .options(
+                selectinload(CPEMatchStringDatabaseModel.matches),
+            )
+            .where(*clauses)
+            .execution_options(yield_per=self._yield_per)
+            .limit(limit)
+        )
+
+        if index is not None:
+            statement = statement.offset(index)
+
+        async with self._db.session() as session, session.begin():
+            result = await session.stream_scalars(statement)
+            async for cpe_model in result:
+                yield cpe_model
+
+    async def all(
+        self, *, limit: int | None = None
+    ) -> AsyncIterator[CPEMatchStringDatabaseModel]:
+        statement = (
+            select(CPEMatchStringDatabaseModel)
+            .options(
+                selectinload(CPEMatchStringDatabaseModel.matches),
+            )
+            .limit(limit)
+            .execution_options(yield_per=self._yield_per)
+        )
+
+        async with self._db.session() as session, session.begin():
+            result = await session.stream_scalars(statement)
+            async for cpe_model in result:
+                yield cpe_model
+
+    async def count(
+        self,
+        *,
+        match_criteria_id: str | None,
+        last_modification_start_date: datetime | None = None,
+        last_modification_end_date: datetime | None = None,
+        published_start_date: datetime | None = None,
+        published_end_date: datetime | None = None,
+    ) -> int:
+        clauses = []
+
+        if match_criteria_id is not None:
+            clauses.append(
+                CPEMatchStringDatabaseModel.match_criteria_id
+                == match_criteria_id
+            )
+
+        if last_modification_start_date:
+            clauses.append(
+                CPEMatchStringDatabaseModel.last_modified
+                >= last_modification_start_date
+            )
+        if last_modification_end_date:
+            clauses.append(
+                CPEMatchStringDatabaseModel.last_modified
+                <= last_modification_end_date
+            )
+        if published_start_date:
+            clauses.append(
+                CPEMatchStringDatabaseModel.published >= published_start_date
+            )
+        if published_end_date:
+            clauses.append(
+                CPEMatchStringDatabaseModel.published <= published_end_date
+            )
+
+        statement = select(
+            func.count(CPEMatchStringDatabaseModel.match_criteria_id)
+        ).where(*clauses)
+        async with self._db.transaction() as transaction:
+            result = await transaction.execute(statement)
+            return result.scalar()  # type: ignore[return-value]

--- a/greenbone/scap/cpe_match/db/manager.py
+++ b/greenbone/scap/cpe_match/db/manager.py
@@ -14,14 +14,12 @@ from sqlalchemy import (
 from sqlalchemy.ext.asyncio import AsyncConnection
 from sqlalchemy.orm import selectinload
 
-from greenbone.scap.db import Database
-
 from greenbone.scap.cpe_match.db.models import (
     BaseDatabaseModel,
-    CPEMatchStringDatabaseModel,
     CPEMatchDatabaseModel,
+    CPEMatchStringDatabaseModel,
 )
-
+from greenbone.scap.db import Database
 
 DEFAULT_THRESHOLD = 100
 DEFAULT_YIELD_PER = 100

--- a/greenbone/scap/cpe_match/db/manager.py
+++ b/greenbone/scap/cpe_match/db/manager.py
@@ -107,7 +107,7 @@ class CPEMatchStringDatabaseManager(AsyncContextManager):
             )
             await self._insert_foreign_data(transaction, match_strings)
 
-        self._cpes = []
+        self._cpe_match_strings = []
 
     async def _insert_foreign_data(
         self,
@@ -150,8 +150,8 @@ class CPEMatchStringDatabaseManager(AsyncContextManager):
         index: int | None = None,
         last_modification_start_date: datetime | None = None,
         last_modification_end_date: datetime | None = None,
-        published_start_date: datetime | None = None,
-        published_end_date: datetime | None = None,
+        created_start_date: datetime | None = None,
+        created_end_date: datetime | None = None,
     ) -> AsyncIterator[CPEMatchStringDatabaseModel]:
         clauses = []
 
@@ -171,13 +171,13 @@ class CPEMatchStringDatabaseManager(AsyncContextManager):
                 CPEMatchStringDatabaseModel.last_modified
                 <= last_modification_end_date
             )
-        if published_start_date:
+        if created_start_date:
             clauses.append(
-                CPEMatchStringDatabaseModel.published >= published_start_date
+                CPEMatchStringDatabaseModel.created >= created_start_date
             )
-        if published_end_date:
+        if created_end_date:
             clauses.append(
-                CPEMatchStringDatabaseModel.published <= published_end_date
+                CPEMatchStringDatabaseModel.created <= created_end_date
             )
 
         statement = (
@@ -221,8 +221,8 @@ class CPEMatchStringDatabaseManager(AsyncContextManager):
         match_criteria_id: str | None,
         last_modification_start_date: datetime | None = None,
         last_modification_end_date: datetime | None = None,
-        published_start_date: datetime | None = None,
-        published_end_date: datetime | None = None,
+        created_start_date: datetime | None = None,
+        created_end_date: datetime | None = None,
     ) -> int:
         clauses = []
 
@@ -242,13 +242,13 @@ class CPEMatchStringDatabaseManager(AsyncContextManager):
                 CPEMatchStringDatabaseModel.last_modified
                 <= last_modification_end_date
             )
-        if published_start_date:
+        if created_start_date:
             clauses.append(
-                CPEMatchStringDatabaseModel.published >= published_start_date
+                CPEMatchStringDatabaseModel.created >= created_start_date
             )
-        if published_end_date:
+        if created_end_date:
             clauses.append(
-                CPEMatchStringDatabaseModel.published <= published_end_date
+                CPEMatchStringDatabaseModel.created <= created_end_date
             )
 
         statement = select(

--- a/greenbone/scap/cpe_match/db/models.py
+++ b/greenbone/scap/cpe_match/db/models.py
@@ -3,18 +3,12 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 
-from datetime import date, datetime
-from enum import StrEnum
-from typing import Annotated
+from datetime import datetime
 
 from sqlalchemy import (
     DateTime,
     ForeignKey,
-    ForeignKeyConstraint,
-    String,
-    TypeDecorator,
     Uuid,
-    and_,
 )
 from sqlalchemy.ext.asyncio import AsyncAttrs
 from sqlalchemy.orm import (
@@ -56,7 +50,7 @@ class CPEMatchStringDatabaseModel(BaseDatabaseModel):
     version_start_excluding: Mapped[str | None]
     version_end_including: Mapped[str | None]
     version_end_excluding: Mapped[str | None]
-    matches: Mapped[list["CPEMatchModel"] | None] = relationship(
+    matches: Mapped[list["CPEMatchDatabaseModel"] | None] = relationship(
         back_populates="cpe_match_string_model"
     )
 

--- a/greenbone/scap/cpe_match/db/models.py
+++ b/greenbone/scap/cpe_match/db/models.py
@@ -1,0 +1,79 @@
+# SPDX-FileCopyrightText: 2024 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+
+from datetime import date, datetime
+from enum import StrEnum
+from typing import Annotated
+
+from sqlalchemy import (
+    DateTime,
+    ForeignKey,
+    ForeignKeyConstraint,
+    String,
+    TypeDecorator,
+    Uuid,
+    and_,
+)
+from sqlalchemy.ext.asyncio import AsyncAttrs
+from sqlalchemy.orm import (
+    DeclarativeBase,
+    Mapped,
+    mapped_column,
+    relationship,
+)
+
+
+class BaseDatabaseModel(AsyncAttrs, DeclarativeBase):
+    type_annotation_map = {
+        datetime: DateTime(timezone=True),
+    }
+
+    def __repr__(self) -> str:
+        repr_string = ", ".join(
+            [
+                f"{key}={value!r}"
+                for key, value in self.__dict__.items()
+                if not key.startswith("_")
+            ]
+        )
+        return f"{self.__class__.__name__}({repr_string})"
+
+
+class CPEMatchStringDatabaseModel(BaseDatabaseModel):
+    __tablename__ = "cpe_match_strings"
+
+    match_criteria_id: Mapped[Uuid] = mapped_column(
+        Uuid(as_uuid=False), primary_key=True
+    )
+    criteria: Mapped[str]
+    status: Mapped[str]
+    cpe_last_modified: Mapped[datetime]
+    created: Mapped[datetime]
+    last_modified: Mapped[datetime]
+    version_start_including: Mapped[str | None]
+    version_start_excluding: Mapped[str | None]
+    version_end_including: Mapped[str | None]
+    version_end_excluding: Mapped[str | None]
+    matches: Mapped[list["CPEMatchModel"] | None] = relationship(
+        back_populates="cpe_match_string_model"
+    )
+
+
+class CPEMatchDatabaseModel(BaseDatabaseModel):
+    __tablename__ = "cpe_match"
+
+    match_criteria_id: Mapped[Uuid] = mapped_column(
+        Uuid(as_uuid=False),
+        ForeignKey("cpe_match_strings.match_criteria_id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    cpe_name: Mapped[str]
+    cpe_name_id: Mapped[Uuid] = mapped_column(
+        Uuid(as_uuid=False), primary_key=True
+    )
+
+    cpe_match_string_model: Mapped[CPEMatchStringDatabaseModel] = relationship(
+        back_populates="matches"
+    )

--- a/greenbone/scap/cpe_match/json.py
+++ b/greenbone/scap/cpe_match/json.py
@@ -7,6 +7,7 @@ import json
 from dataclasses import asdict, dataclass
 from datetime import datetime
 from pathlib import Path
+from typing import Sequence
 
 from pontos.nvd.models.cpe_match_string import CPEMatchString
 from rich.console import Console
@@ -65,7 +66,7 @@ class MatchStringJsonManager(JsonManager):
         storage_path: Path,
         *,
         compress: bool = False,
-        schema_path: Path = None,
+        schema_path: Path | None = None,
         raise_error_on_validation=False,
     ):
         super().__init__(
@@ -88,7 +89,9 @@ class MatchStringJsonManager(JsonManager):
             MatchStringItem(match_string=match_string)
         )
 
-    def add_match_strings(self, match_strings: list[CPEMatchString]) -> None:
+    def add_match_strings(
+        self, match_strings: Sequence[CPEMatchString]
+    ) -> None:
         for match_string in match_strings:
             self.add_match_string(match_string)
 

--- a/greenbone/scap/cpe_match/json.py
+++ b/greenbone/scap/cpe_match/json.py
@@ -1,0 +1,117 @@
+# SPDX-FileCopyrightText: 2024 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import gzip
+import json
+from dataclasses import asdict, dataclass
+from datetime import datetime
+from pathlib import Path
+
+from pontos.nvd.models.cpe_match_string import CPEMatchString
+from rich.console import Console
+
+from greenbone.scap.data_utils.json import (
+    JsonEncoder,
+    JsonManager,
+)
+
+
+@dataclass
+class MatchStringItem:
+    """
+    Data class to represent a CPE match string item.
+
+    Attributes:
+        match_string: The match string instance associated with this item.
+    """
+
+    match_string: CPEMatchString
+
+
+@dataclass
+class MatchStringResponse:
+    """
+    Data class to represent a response containing CPE match string data.
+
+    Attributes:
+        results_per_page: Number of results per page.
+        start_index: The starting index of the results.
+        total_results: Total number of results.
+        timestamp: Timestamp of the response creation.
+        products: List of products.
+        format: Format of the response, default is "NVD_CPE".
+        version: Version of the response format, default is "2.0".
+    """
+
+    results_per_page: int
+    start_index: int
+    total_results: int
+    timestamp: datetime
+    match_strings: list[MatchStringItem]
+
+    format: str = "NVD_CPEMatchString"
+    version: str = "2.0"
+
+
+class MatchStringJsonManager(JsonManager):
+    """
+    Manages the storage and organization of CPE match data.
+    """
+
+    def __init__(
+        self,
+        error_console: Console,
+        storage_path: Path,
+        *,
+        compress: bool = False,
+        schema_path: Path = None,
+        raise_error_on_validation=False,
+    ):
+        super().__init__(
+            error_console=error_console,
+            schema_path=schema_path,
+            raise_error_on_validation=raise_error_on_validation,
+        )
+        self._match_string_response = MatchStringResponse(
+            results_per_page=1,
+            start_index=0,
+            total_results=1,
+            timestamp=datetime.now(),
+            match_strings=[],
+        )
+        self._compress: bool = compress
+        self._storage_path: Path = storage_path
+
+    def add_match_string(self, match_string: CPEMatchString) -> None:
+        self._match_string_response.match_strings.append(
+            MatchStringItem(match_string=match_string)
+        )
+
+    def add_match_strings(self, match_strings: list[CPEMatchString]) -> None:
+        for match_string in match_strings:
+            self.add_match_string(match_string)
+
+    def write(self) -> None:
+        """
+        Write the CPE data to JSON files with optional compression in the specified folder.
+        """
+
+        self._match_string_response.results_per_page = len(
+            self._match_string_response.match_strings
+        )
+        self._match_string_response.total_results = len(
+            self._match_string_response.match_strings
+        )
+
+        json_data = json.dumps(
+            asdict(self._match_string_response), cls=JsonEncoder, indent=1
+        )
+        self._validate_json("nvd-cpe-matches", json_data)
+
+        if self._compress:
+            path = self._storage_path / "nvd-cpe-matches.json.gz"
+            path.write_bytes(gzip.compress(json_data.encode("utf-8")))
+        else:
+            path = self._storage_path / "nvd-cpe-matches.json"
+            path.write_bytes(json_data.encode("utf-8"))

--- a/greenbone/scap/cpe_match/producer/__init__.py
+++ b/greenbone/scap/cpe_match/producer/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2024 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later

--- a/greenbone/scap/cpe_match/producer/nvd_api.py
+++ b/greenbone/scap/cpe_match/producer/nvd_api.py
@@ -1,0 +1,92 @@
+# SPDX-FileCopyrightText: 2024 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+from argparse import ArgumentParser, Namespace
+
+from rich.console import Console
+from rich.progress import Progress
+
+from pontos.nvd import NVDResults, NVDApi
+from pontos.nvd.cpe_match import CPEMatchApi
+from pontos.nvd.models.cpe_match_string import CPEMatchString
+
+from ..cli.processor import CPE_MATCH_TYPE_PLURAL
+from ...generic_cli.producer.nvd_api import NvdApiProducer
+
+
+class CpeMatchNvdApiProducer(NvdApiProducer[CPEMatchString]):
+
+    item_type_plural = CPE_MATCH_TYPE_PLURAL
+    arg_defaults = NvdApiProducer.arg_defaults
+
+    @classmethod
+    def from_args(
+        cls,
+        args: Namespace,
+        console: Console,
+        error_console: Console,
+        progress: Progress,
+    ) -> "CpeMatchNvdApiProducer":
+
+        request_filter_opts = {}
+
+        since = NvdApiProducer.since_from_args(args, error_console)
+        request_filter_opts["last_modified_start_date"] = since
+
+        return CpeMatchNvdApiProducer(
+            console,
+            error_console,
+            progress,
+            args.nvd_api_key,
+            verbose=args.verbose or 0,
+            retry_attempts=args.retry_attempts,
+            request_results=args.number,
+            request_filter_opts=request_filter_opts,
+            start_index=args.start,
+        )
+
+    def __init__(
+        self,
+        console: Console,
+        error_console: Console,
+        progress: Progress,
+        nvd_api_key: str | None = None,
+        *,
+        verbose: int = None,
+        retry_attempts: int = None,
+        request_results: int = None,
+        request_filter_opts: dict = {},
+        start_index: int = 0,
+    ):
+        super().__init__(
+            console,
+            error_console,
+            progress,
+            verbose=verbose,
+            retry_attempts=retry_attempts,
+            request_results=request_results,
+            request_filter_opts=request_filter_opts,
+            start_index=start_index,
+        )
+
+    def _create_nvd_api(self, nvd_api_key: str) -> NVDApi:
+        return CPEMatchApi(
+            token=nvd_api_key,
+        )
+
+    async def _create_nvd_results(self) -> NVDResults[CPEMatchString]:
+        return await self._nvd_api.cpe_matches(
+            last_modified_start_date=self.request_filter_opts.get(
+                "last_modified_start_date"
+            ),
+            last_modified_end_date=self.request_filter_opts.get(
+                "last_modified_start_date"
+            ),
+            cve_id=self.request_filter_opts.get("cve_id"),
+            match_string_search=self.request_filter_opts.get(
+                "match_string_search"
+            ),
+            request_results=self.request_results,
+            start_index=self.start_index,
+            results_per_page=self.queue.chunk_size,
+        )

--- a/greenbone/scap/cpe_match/producer/nvd_api.py
+++ b/greenbone/scap/cpe_match/producer/nvd_api.py
@@ -1,21 +1,19 @@
 # SPDX-FileCopyrightText: 2024 Greenbone AG
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
-from argparse import ArgumentParser, Namespace
+from argparse import Namespace
 
+from pontos.nvd import NVDApi, NVDResults
+from pontos.nvd.cpe_match import CPEMatchApi
+from pontos.nvd.models.cpe_match_string import CPEMatchString
 from rich.console import Console
 from rich.progress import Progress
 
-from pontos.nvd import NVDResults, NVDApi
-from pontos.nvd.cpe_match import CPEMatchApi
-from pontos.nvd.models.cpe_match_string import CPEMatchString
-
-from ..cli.processor import CPE_MATCH_TYPE_PLURAL
 from ...generic_cli.producer.nvd_api import NvdApiProducer
+from ..cli.processor import CPE_MATCH_TYPE_PLURAL
 
 
 class CpeMatchNvdApiProducer(NvdApiProducer[CPEMatchString]):
-
     item_type_plural = CPE_MATCH_TYPE_PLURAL
     arg_defaults = NvdApiProducer.arg_defaults
 
@@ -27,7 +25,6 @@ class CpeMatchNvdApiProducer(NvdApiProducer[CPEMatchString]):
         error_console: Console,
         progress: Progress,
     ) -> "CpeMatchNvdApiProducer":
-
         request_filter_opts = {}
 
         since = NvdApiProducer.since_from_args(args, error_console)
@@ -37,12 +34,12 @@ class CpeMatchNvdApiProducer(NvdApiProducer[CPEMatchString]):
             console,
             error_console,
             progress,
-            args.nvd_api_key,
-            verbose=args.verbose or 0,
+            nvd_api_key=args.nvd_api_key,
             retry_attempts=args.retry_attempts,
             request_results=args.number,
             request_filter_opts=request_filter_opts,
             start_index=args.start,
+            verbose=args.verbose or 0,
         )
 
     def __init__(
@@ -50,23 +47,24 @@ class CpeMatchNvdApiProducer(NvdApiProducer[CPEMatchString]):
         console: Console,
         error_console: Console,
         progress: Progress,
-        nvd_api_key: str | None = None,
         *,
-        verbose: int = None,
+        nvd_api_key: str | None = None,
         retry_attempts: int = None,
         request_results: int = None,
         request_filter_opts: dict = {},
         start_index: int = 0,
+        verbose: int = None,
     ):
         super().__init__(
             console,
             error_console,
             progress,
-            verbose=verbose,
+            nvd_api_key=nvd_api_key,
             retry_attempts=retry_attempts,
             request_results=request_results,
             request_filter_opts=request_filter_opts,
             start_index=start_index,
+            verbose=verbose,
         )
 
     def _create_nvd_api(self, nvd_api_key: str) -> NVDApi:

--- a/greenbone/scap/cpe_match/producer/nvd_api.py
+++ b/greenbone/scap/cpe_match/producer/nvd_api.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 from argparse import Namespace
 
-from pontos.nvd import NVDApi, NVDResults
+from pontos.nvd import NVDResults
 from pontos.nvd.cpe_match import CPEMatchApi
 from pontos.nvd.models.cpe_match_string import CPEMatchString
 from rich.console import Console
@@ -14,8 +14,16 @@ from ..cli.processor import CPE_MATCH_TYPE_PLURAL
 
 
 class CpeMatchNvdApiProducer(NvdApiProducer[CPEMatchString]):
-    item_type_plural = CPE_MATCH_TYPE_PLURAL
-    arg_defaults = NvdApiProducer.arg_defaults
+    """
+    Abstract async context manager class for a producer querying
+    CPE match strings from an NVD API.
+    """
+
+    _item_type_plural = CPE_MATCH_TYPE_PLURAL
+    "Plural form of the type of items to use in log messages"
+
+    _arg_defaults = NvdApiProducer._arg_defaults
+    "Default values for optional arguments."
 
     @classmethod
     def from_args(
@@ -25,6 +33,19 @@ class CpeMatchNvdApiProducer(NvdApiProducer[CPEMatchString]):
         error_console: Console,
         progress: Progress,
     ) -> "CpeMatchNvdApiProducer":
+        """
+        Create a new `CPEMatchNvdApiProducer` with parameters from
+         the given command line args gathered by an `ArgumentParser`.
+
+        Args:
+            args: Command line arguments to use
+            console: Console for standard output.
+            error_console: Console for error output.
+            progress: Progress bar renderer to be updated by the producer.
+
+        Returns:
+            The new `CPEMatchNvdApiProducer`.
+        """
         request_filter_opts = {}
 
         since = NvdApiProducer.since_from_args(args, error_console)
@@ -55,6 +76,20 @@ class CpeMatchNvdApiProducer(NvdApiProducer[CPEMatchString]):
         start_index: int = 0,
         verbose: int = None,
     ):
+        """
+        Constructor for a CPE match string NVD API producer.
+
+        Args:
+            console: Console for standard output.
+            error_console: Console for error output.
+            progress: Progress bar renderer to be updated by the producer.
+            retry_attempts: Number of retries for downloading items
+            nvd_api_key: API key to use for the requests to allow faster requests
+            request_results: Total number of results to request from the API
+            request_filter_opts: Filter options to pass to the API requests
+            start_index: index/offset of the first item to request
+            verbose: Verbosity level of log messages.
+        """
         super().__init__(
             console,
             error_console,
@@ -67,24 +102,39 @@ class CpeMatchNvdApiProducer(NvdApiProducer[CPEMatchString]):
             verbose=verbose,
         )
 
-    def _create_nvd_api(self, nvd_api_key: str) -> NVDApi:
+    def _create_nvd_api(self, nvd_api_key: str) -> CPEMatchApi:
+        """
+        Callback used by the constructor to create the NVD API object
+        that can be queried for CPE match strings.
+
+        Args:
+            nvd_api_key: An optional API key to allow faster requests.
+
+        Returns: The new `CPEMatchApi` object, which inherits from `NVDApi`.
+        """
         return CPEMatchApi(
             token=nvd_api_key,
         )
 
     async def _create_nvd_results(self) -> NVDResults[CPEMatchString]:
+        """
+        Callback used during `fetch_initial_data` getting
+        the `NVDResults` object the CPE match strings will be fetched from.
+
+        Returns: The new `NVDResults` object.
+        """
         return await self._nvd_api.cpe_matches(
-            last_modified_start_date=self.request_filter_opts.get(
+            last_modified_start_date=self._request_filter_opts.get(
                 "last_modified_start_date"
             ),
-            last_modified_end_date=self.request_filter_opts.get(
+            last_modified_end_date=self._request_filter_opts.get(
                 "last_modified_start_date"
             ),
-            cve_id=self.request_filter_opts.get("cve_id"),
-            match_string_search=self.request_filter_opts.get(
+            cve_id=self._request_filter_opts.get("cve_id"),
+            match_string_search=self._request_filter_opts.get(
                 "match_string_search"
             ),
-            request_results=self.request_results,
-            start_index=self.start_index,
-            results_per_page=self.queue.chunk_size,
+            request_results=self._request_results,
+            start_index=self._start_index,
+            results_per_page=self._queue.chunk_size,
         )

--- a/greenbone/scap/cpe_match/worker/__init__.py
+++ b/greenbone/scap/cpe_match/worker/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2024 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later

--- a/greenbone/scap/cpe_match/worker/db.py
+++ b/greenbone/scap/cpe_match/worker/db.py
@@ -1,0 +1,84 @@
+# SPDX-FileCopyrightText: 2024 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from pathlib import Path
+from argparse import Namespace
+from typing import Sequence, AsyncContextManager
+
+from pontos.nvd.models.cpe_match_string import CPEMatchString
+from rich.console import Console
+from rich.progress import Progress
+
+from ..cli.processor import CPE_MATCH_TYPE_PLURAL
+from ..db.manager import CPEMatchStringDatabaseManager
+from ...cli import DEFAULT_VERBOSITY
+from ...generic_cli.worker.db import ScapDatabaseWriteWorker
+
+
+class CpeMatchDatabaseWriteWorker(ScapDatabaseWriteWorker[CPEMatchString]):
+
+    item_type_plural = CPE_MATCH_TYPE_PLURAL
+    arg_defaults = ScapDatabaseWriteWorker.arg_defaults
+
+    @classmethod
+    def get_item_type_plural(cls):
+        return "CPE Match Strings"
+
+    @classmethod
+    def from_args(
+        cls,
+        args: Namespace,
+        console: Console,
+        error_console: Console,
+        progress: Progress,
+    ) -> "CpeMatchDatabaseWriteWorker":
+
+        return CpeMatchDatabaseWriteWorker(
+            console,
+            error_console,
+            progress,
+            database_name=args.database_name,
+            database_schema=args.database_schema,
+            database_host=args.database_host,
+            database_port=args.database_port,
+            database_user=args.database_user,
+            database_password=args.database_password,
+            echo_sql=args.echo_sql,
+            verbose=args.verbose or 0,
+        )
+
+    def __init__(
+        self,
+        console: Console,
+        error_console: Console,
+        progress: Progress,
+        *,
+        database_name: str,
+        database_schema: str,
+        database_host: str,
+        database_port: int,
+        database_user: str,
+        database_password: str,
+        echo_sql: bool = False,
+        verbose: int = DEFAULT_VERBOSITY,
+    ):
+        super().__init__(
+            console,
+            error_console,
+            progress,
+            database_name=database_name,
+            database_schema=database_schema,
+            database_host=database_host,
+            database_port=database_port,
+            database_user=database_user,
+            database_password=database_password,
+            echo_sql=echo_sql,
+            verbose=verbose,
+        )
+
+    async def add_chunk(self, chunk: Sequence[CPEMatchString]):
+        await self._manager.add_cpe_match_strings(chunk)
+
+    def _create_manager(self) -> AsyncContextManager:
+        return CPEMatchStringDatabaseManager(self._database)

--- a/greenbone/scap/cpe_match/worker/db.py
+++ b/greenbone/scap/cpe_match/worker/db.py
@@ -19,7 +19,7 @@ class CpeMatchDatabaseWriteWorker(ScapDatabaseWriteWorker[CPEMatchString]):
     _item_type_plural = CPE_MATCH_TYPE_PLURAL
     "Plural form of the type of items to use in log messages."
 
-    _arg_defaults = ScapDatabaseWriteWorker.arg_defaults
+    _arg_defaults = ScapDatabaseWriteWorker._arg_defaults
     "Default values for optional arguments."
 
     @classmethod

--- a/greenbone/scap/cpe_match/worker/db.py
+++ b/greenbone/scap/cpe_match/worker/db.py
@@ -2,22 +2,20 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from pathlib import Path
 from argparse import Namespace
-from typing import Sequence, AsyncContextManager
+from typing import AsyncContextManager, Sequence
 
 from pontos.nvd.models.cpe_match_string import CPEMatchString
 from rich.console import Console
 from rich.progress import Progress
 
-from ..cli.processor import CPE_MATCH_TYPE_PLURAL
-from ..db.manager import CPEMatchStringDatabaseManager
 from ...cli import DEFAULT_VERBOSITY
 from ...generic_cli.worker.db import ScapDatabaseWriteWorker
+from ..cli.processor import CPE_MATCH_TYPE_PLURAL
+from ..db.manager import CPEMatchStringDatabaseManager
 
 
 class CpeMatchDatabaseWriteWorker(ScapDatabaseWriteWorker[CPEMatchString]):
-
     item_type_plural = CPE_MATCH_TYPE_PLURAL
     arg_defaults = ScapDatabaseWriteWorker.arg_defaults
 
@@ -33,7 +31,6 @@ class CpeMatchDatabaseWriteWorker(ScapDatabaseWriteWorker[CPEMatchString]):
         error_console: Console,
         progress: Progress,
     ) -> "CpeMatchDatabaseWriteWorker":
-
         return CpeMatchDatabaseWriteWorker(
             console,
             error_console,

--- a/greenbone/scap/cpe_match/worker/db.py
+++ b/greenbone/scap/cpe_match/worker/db.py
@@ -92,6 +92,8 @@ class CpeMatchDatabaseWriteWorker(ScapDatabaseWriteWorker[CPEMatchString]):
             echo_sql: Whether to print SQL statements.
             verbose: Verbosity level of log messages.
         """
+        self._manager: CPEMatchStringDatabaseManager
+
         super().__init__(
             console,
             error_console,

--- a/greenbone/scap/cpe_match/worker/json.py
+++ b/greenbone/scap/cpe_match/worker/json.py
@@ -1,0 +1,76 @@
+# SPDX-FileCopyrightText: 2024 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from pathlib import Path
+from argparse import Namespace
+from typing import Sequence
+
+from pontos.nvd.models.cpe_match_string import CPEMatchString
+from rich.console import Console
+from rich.progress import Progress
+
+from ..cli.processor import CPE_MATCH_TYPE_PLURAL
+from ..json import MatchStringJsonManager
+from ...generic_cli.worker.json import ScapJsonWriteWorker
+
+
+class CpeMatchJsonWriteWorker(ScapJsonWriteWorker[CPEMatchString]):
+
+    item_type_plural = CPE_MATCH_TYPE_PLURAL
+    arg_defaults = ScapJsonWriteWorker.arg_defaults
+
+    @classmethod
+    def from_args(
+        cls,
+        args: Namespace,
+        console: Console,
+        error_console: Console,
+        progress: Progress,
+    ) -> "CpeMatchJsonWriteWorker":
+
+        return CpeMatchJsonWriteWorker(
+            console,
+            error_console,
+            progress,
+            storage_path=args.storage_path or cls.arg_defaults["storage_path"],
+            schema_path=args.schema_path or cls.arg_defaults["schema_path"],
+            compress=args.compress if not None else False,
+            verbose=args.verbose or 0,
+        )
+
+    def __init__(
+        self,
+        console: Console,
+        error_console: Console,
+        progress: Progress,
+        *,
+        storage_path: Path,
+        schema_path: Path | None = None,
+        compress: bool = False,
+        verbose: int | None = None,
+    ):
+        super().__init__(
+            console,
+            error_console,
+            progress,
+            storage_path=storage_path,
+            schema_path=schema_path,
+            compress=compress,
+            verbose=verbose,
+        )
+
+        self.json_manager = MatchStringJsonManager(
+            error_console,
+            storage_path,
+            compress=compress,
+            schema_path=schema_path,
+            raise_error_on_validation=False,
+        )
+
+    async def add_chunk(self, chunk: Sequence[CPEMatchString]):
+        self.json_manager.add_match_strings(chunk)
+
+    async def loop_end(self) -> None:
+        self.json_manager.write()
+        await super().loop_end()

--- a/greenbone/scap/cpe_match/worker/json.py
+++ b/greenbone/scap/cpe_match/worker/json.py
@@ -2,21 +2,20 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from pathlib import Path
 from argparse import Namespace
+from pathlib import Path
 from typing import Sequence
 
 from pontos.nvd.models.cpe_match_string import CPEMatchString
 from rich.console import Console
 from rich.progress import Progress
 
+from ...generic_cli.worker.json import ScapJsonWriteWorker
 from ..cli.processor import CPE_MATCH_TYPE_PLURAL
 from ..json import MatchStringJsonManager
-from ...generic_cli.worker.json import ScapJsonWriteWorker
 
 
 class CpeMatchJsonWriteWorker(ScapJsonWriteWorker[CPEMatchString]):
-
     item_type_plural = CPE_MATCH_TYPE_PLURAL
     arg_defaults = ScapJsonWriteWorker.arg_defaults
 
@@ -28,7 +27,6 @@ class CpeMatchJsonWriteWorker(ScapJsonWriteWorker[CPEMatchString]):
         error_console: Console,
         progress: Progress,
     ) -> "CpeMatchJsonWriteWorker":
-
         return CpeMatchJsonWriteWorker(
             console,
             error_console,

--- a/greenbone/scap/cpe_match/worker/json.py
+++ b/greenbone/scap/cpe_match/worker/json.py
@@ -111,11 +111,11 @@ class CpeMatchJsonWriteWorker(ScapJsonWriteWorker[CPEMatchString]):
         """
         self._json_manager.add_match_strings(chunk)
 
-    async def loop_end(self) -> None:
+    async def _loop_end(self) -> None:
         """
         Callback handling the exiting the main worker loop.
 
         Makes the JSON manager write the document to the file.
         """
         self._json_manager.write()
-        await super().loop_end()
+        await super()._loop_end()

--- a/greenbone/scap/cve/cli/download.py
+++ b/greenbone/scap/cve/cli/download.py
@@ -432,10 +432,14 @@ async def download(console: Console, error_console: Console):
                 )
 
         if run_time_file:
+            if until:
+                run_time = until
+            else:
+                run_time = datetime.now()
             # ensure directories exist
             run_time_file.parent.mkdir(parents=True, exist_ok=True)
             run_time_file.write_text(
-                f"{until.isoformat()}\n",
+                f"{run_time.isoformat()}\n",
                 encoding="utf8",  # type: ignore
             )
             console.log(f"Wrote run time to {run_time_file.absolute()}.")

--- a/greenbone/scap/cve/cli/download.py
+++ b/greenbone/scap/cve/cli/download.py
@@ -435,7 +435,8 @@ async def download(console: Console, error_console: Console):
             # ensure directories exist
             run_time_file.parent.mkdir(parents=True, exist_ok=True)
             run_time_file.write_text(
-                f"{until.isoformat()}\n", encoding="utf8"  # type: ignore
+                f"{until.isoformat()}\n",
+                encoding="utf8",  # type: ignore
             )
             console.log(f"Wrote run time to {run_time_file.absolute()}.")
 

--- a/greenbone/scap/data_utils/__init__.py
+++ b/greenbone/scap/data_utils/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2024 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later

--- a/greenbone/scap/data_utils/json.py
+++ b/greenbone/scap/data_utils/json.py
@@ -123,7 +123,7 @@ class JsonManager:
     def __init__(
         self,
         error_console: Console,
-        schema_path: Path = None,
+        schema_path: Path | None = None,
         raise_error_on_validation=False,
     ):
         """

--- a/greenbone/scap/data_utils/json.py
+++ b/greenbone/scap/data_utils/json.py
@@ -120,7 +120,6 @@ class JsonEncoder(json.JSONEncoder):
 
 
 class JsonManager:
-
     def __init__(
         self,
         error_console: Console,

--- a/greenbone/scap/data_utils/json.py
+++ b/greenbone/scap/data_utils/json.py
@@ -1,0 +1,195 @@
+# SPDX-FileCopyrightText: 2024 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import json
+import re
+import uuid
+from datetime import date, datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import fastjsonschema
+from rich.console import Console
+
+UUID_PATTERN = re.compile(
+    r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
+)
+
+
+def _custom_uuid_validate(value):
+    """
+    Validate whether the given value matches a UUID pattern.
+
+    Parameters:
+        value: The value to be validated as a UUID.
+
+    Returns:
+        True if the value matches the UUID pattern, False otherwise.
+    """
+
+    if UUID_PATTERN.match(value):
+        return True
+
+
+class JsonEncoder(json.JSONEncoder):
+    """
+    A custom JSON encoder that converts dictionary keys from snake_case to camelCase
+    and serializes datetime and date objects to ISO format.
+    """
+
+    def _snake_to_camel(self, snake_str: str) -> str:
+        """
+        Convert a snake_case string to camelCase.
+
+        Args:
+            snake_str: The snake_case string to convert.
+
+        Returns:
+            The camelCase version of the input string.
+        """
+        components = snake_str.split("_")
+        return components[0] + "".join(x.title() for x in components[1:])
+
+    def _convert_keys_to_camel(self, obj: Any) -> Any:
+        """
+        Recursively convert all dictionary keys in an object from snake_case to camelCase
+        and exclude all None/null values.
+
+        Args:
+            obj: The object to convert, which can be a dictionary, list, or other type.
+
+        Returns:
+            The converted object with camelCase keys.
+        """
+
+        if isinstance(obj, dict):
+            new_obj = {}
+            for k, v in obj.items():
+                # Exclude None values
+                new_v = self._convert_keys_to_camel(v)
+                if new_v is not None:
+                    new_key = self._snake_to_camel(k)
+                    new_obj[new_key] = new_v
+            return new_obj
+        elif isinstance(obj, list):
+            return [self._convert_keys_to_camel(item) for item in obj]
+        else:
+            return obj
+
+    def default(self, obj: Any) -> Any:
+        """
+        Handle custom serialization for datetime and date objects.
+
+        Args:
+            obj: The object to serialize.
+
+        Returns:
+            The serialized form of the datetime or date object, or the default JSON encoding.
+        """
+
+        if isinstance(obj, datetime):
+            return (
+                obj.astimezone(timezone.utc)
+                .replace(tzinfo=None)
+                .isoformat(timespec="milliseconds")
+                + "Z"
+                if obj.tzinfo
+                else obj.isoformat(timespec="milliseconds") + "Z"
+            )
+        elif isinstance(obj, date):
+            return obj.isoformat()
+        elif isinstance(obj, uuid.UUID):
+            return str(obj).upper()
+
+        return super().default(obj)
+
+    def encode(self, obj: Any) -> Any:
+        """
+        Encode an object to JSON format, converting keys to camelCase.
+
+        Args:
+            obj: The object to encode.
+
+        Returns:
+            The JSON-encoded string with camelCase keys.
+        """
+
+        camel_case_obj = self._convert_keys_to_camel(obj)
+        return super().encode(camel_case_obj)
+
+
+class JsonManager:
+
+    def __init__(
+        self,
+        error_console: Console,
+        schema_path: Path = None,
+        raise_error_on_validation=False,
+    ):
+        """
+        Initializes the JsonManager
+
+        Parameters:
+            error_console:
+                An instance of the Console class used for logging errors and
+                validation messages.
+            schema_path:
+                A Path object pointing to the JSON schema file used for validating
+                CPE data. If provided, the schema is loaded during initialization.
+            raise_error_on_validation:
+                If True, raises an exception on json validation errors.
+                If False, log validation warnings.
+        Attributes:
+            _error_console:
+                The Console instance for error and validation message output.
+            validate:
+                A compiled validation function for the schema, or None if no schema
+                is provided.
+            _raise_error_on_validation:
+                Raises an exception on json validation errors.
+        """
+
+        self._error_console = error_console
+        self.validate = (
+            fastjsonschema.compile(
+                json.loads(schema_path.read_text()),
+                formats={"uuid": _custom_uuid_validate},
+            )
+            if schema_path
+            else None
+        )
+        self._raise_error_on_validation = raise_error_on_validation
+
+    def _validate_json(self, name: str, data: str) -> None:
+        """
+        Validates JSON data against a predefined schema.
+
+        Parameters:
+            name: A name identifier for the JSON data being validated. Used in error messages.
+            data: The JSON data in string format to be validated.
+
+        Raises:
+            JsonSchemaException: If the JSON data does not conform to the schema.
+
+        Notes:
+            - If `self.validate` is None or empty, the method returns without performing validation.
+        """
+
+        if not self.validate:
+            return
+
+        try:
+            self.validate(json.loads(data))
+        except fastjsonschema.JsonSchemaException as e:
+            msg = (
+                f"JSON file {name} is invalid."
+                f" Name: {e.name} Value: {e.value}"
+                f" Definition: {e.definition}"
+                f" Rule: {e.rule}"
+            )
+            # Work around progress bar issue with console_error
+            print(msg)
+            self._error_console.print(msg)
+            if self._raise_error_on_validation:
+                raise e

--- a/greenbone/scap/generic_cli/__init__.py
+++ b/greenbone/scap/generic_cli/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2024 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later

--- a/greenbone/scap/generic_cli/processor.py
+++ b/greenbone/scap/generic_cli/processor.py
@@ -13,45 +13,63 @@ from .queue import DEFAULT_CHUNK_SIZE, DEFAULT_QUEUE_SIZE, ScapChunkQueue
 from .worker.base import BaseScapWorker
 
 T = TypeVar("T")
+"Generic type variable for the type of SCAP items handled"
 
 
 class ScapProcessor(Generic[T]):
-    item_type_plural = "SCAP items"
-    arg_defaults = {
+    """
+    Generic class that handles a producer object generating SCAP items
+    to be processed by a worker object.
+
+    The type of the SCAP items is to be specified by the generic type,
+    e.g. `ScapProcessor[CPE]` will be a processor handling CPE objects.
+    """
+
+    _item_type_plural = "SCAP items"
+    "Plural form of the type of items to use in log messages."
+
+    _arg_defaults = {
         "chunk_size": DEFAULT_CHUNK_SIZE,
         "queue_size": DEFAULT_QUEUE_SIZE,
         "verbose": DEFAULT_VERBOSITY,
     }
+    "Default values for optional arguments."
 
     @classmethod
     def add_args_to_parser(
         cls,
         parser: ArgumentParser,
     ):
+        """
+        Adds arguments common to all SCAP processors to an `ArgumentParser`.
+
+        Args:
+            parser: The parser to add arguments to.
+        """
         parser.add_argument(
             "--chunk-size",
-            help=f"Number of {cls.item_type_plural} to download and process in one request. "
+            help=f"Number of {cls._item_type_plural} to download and process in one request. "
             "A lower number allows for more frequent updates and feedback. "
             "Default: %(default)s.",
             type=int,
             metavar="N",
-            default=cls.arg_defaults["chunk_size"],
+            default=cls._arg_defaults["chunk_size"],
         )
         parser.add_argument(
             "--queue-size",
             help="Size of the download queue. It sets the maximum number of "
-            f"{cls.item_type_plural} kept in the memory. "
+            f"{cls._item_type_plural} kept in the memory. "
             "The maximum number of CPEs is chunk size * queue size. "
             "Default: %(default)s.",
             type=int,
             metavar="N",
-            default=cls.arg_defaults["chunk_size"],
+            default=cls._arg_defaults["chunk_size"],
         )
         parser.add_argument(
             "-v",
             "--verbose",
             action="count",
-            default=cls.arg_defaults["verbose"],
+            default=cls._arg_defaults["verbose"],
             help="Enable verbose output.",
         )
 
@@ -66,31 +84,70 @@ class ScapProcessor(Generic[T]):
         chunk_size: int | None = None,
         verbose: int | None = None,
     ):
-        self.console = console
-        self.error_console = error_console
-        self.producer: BaseScapProducer[T] = producer
-        self.worker: BaseScapWorker[T] = worker
+        """
+        Constructor for a new SCAP processor.
 
-        self.queue: ScapChunkQueue[T] = ScapChunkQueue[T](
-            queue_size=queue_size or self.arg_defaults["queue_size"],
-            chunk_size=chunk_size or self.arg_defaults["chunk_size"],
+        Args:
+            console: Console for standard output.
+            error_console: Console for error output.
+            producer: The producer generating the SCAP items.
+            worker: The worker processing the SCAP items.
+            queue_size: The number of chunks allowed in the queue.
+            chunk_size: The expected maximum number of SCAP items per chunk.
+            verbose: Verbosity level of log messages.
+        """
+
+        self._console: Console = console
+        "Console for standard output."
+
+        self._error_console: Console = error_console
+        "Console for error output."
+
+        self._producer: BaseScapProducer[T] = producer
+        "The producer generating the SCAP items."
+
+        self._worker: BaseScapWorker[T] = worker
+        "The worker processing the SCAP items."
+
+        self._queue: ScapChunkQueue[T] = ScapChunkQueue[T](
+            queue_size=queue_size or self._arg_defaults["queue_size"],
+            chunk_size=chunk_size or self._arg_defaults["chunk_size"],
         )
-        self.producer.set_queue(self.queue)
-        self.worker.set_queue(self.queue)
+        "Queue the producer will add chunks to and the worker get chunks from."
+        self._producer.set_queue(self._queue)
+        self._worker.set_queue(self._queue)
 
-        self.verbose = (verbose if not None else self.arg_defaults["verbose"],)
+        self._verbose: int = (
+            verbose if not None else self._arg_defaults["verbose"],
+        )
+        "Verbosity level of log messages."
 
-    async def run(self):
-        async with self.producer, self.worker:
-            total_items = await self.producer.fetch_initial_data()
+    async def run(self) -> None:
+        """
+        Runs the main loops of the producer and worker objects as concurrent
+        subroutines.
+
+        This also handles the producer and worker as context managers and
+        fetches initial data like the expected total number of items from the
+        producer.
+
+        The function will block until the producer finishes and the queue
+        is empty and finished processing.
+        """
+        async with self._producer, self._worker:
+            total_items = await self._producer.fetch_initial_data()
             if total_items <= 0:
                 return
+            self._queue.total_items = total_items
 
             async with asyncio.TaskGroup() as tg:
-                producer_task = tg.create_task(self.producer.run_loop())
-                tg.create_task(self.worker.run_loop())
+                producer_task = tg.create_task(self._producer.run_loop())
+                tg.create_task(self._worker.run_loop())
                 await producer_task
                 await self._join()
 
-    async def _join(self):
-        await self.queue.join()
+    async def _join(self) -> None:
+        """
+        Blocks until all chunks in the queue are fetched and processed.
+        """
+        await self._queue.join()

--- a/greenbone/scap/generic_cli/processor.py
+++ b/greenbone/scap/generic_cli/processor.py
@@ -1,26 +1,21 @@
 # SPDX-FileCopyrightText: 2024 Greenbone AG
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
-from abc import abstractmethod, ABC, abstractclassmethod
-from argparse import ArgumentParser, Namespace
-from typing import TypeVar, Generic, Sequence, Any
-
 import asyncio
-import shtab
+from argparse import ArgumentParser
+from typing import Generic, TypeVar
+
 from rich.console import Console
 
-from .producer.base import BaseScapProducer
-from .queue import ScapChunkQueue, DEFAULT_QUEUE_SIZE, DEFAULT_CHUNK_SIZE
-from .worker.base import BaseScapWorker
-
 from ..cli import DEFAULT_VERBOSITY
-
+from .producer.base import BaseScapProducer
+from .queue import DEFAULT_CHUNK_SIZE, DEFAULT_QUEUE_SIZE, ScapChunkQueue
+from .worker.base import BaseScapWorker
 
 T = TypeVar("T")
 
 
 class ScapProcessor(Generic[T]):
-
     item_type_plural = "SCAP items"
     arg_defaults = {
         "chunk_size": DEFAULT_CHUNK_SIZE,

--- a/greenbone/scap/generic_cli/processor.py
+++ b/greenbone/scap/generic_cli/processor.py
@@ -118,7 +118,7 @@ class ScapProcessor(Generic[T]):
         self._worker.set_queue(self._queue)
 
         self._verbose: int = (
-            verbose if not None else self._arg_defaults["verbose"],
+            verbose if verbose is not None else self._arg_defaults["verbose"]
         )
         "Verbosity level of log messages."
 

--- a/greenbone/scap/generic_cli/processor.py
+++ b/greenbone/scap/generic_cli/processor.py
@@ -1,0 +1,101 @@
+# SPDX-FileCopyrightText: 2024 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+from abc import abstractmethod, ABC, abstractclassmethod
+from argparse import ArgumentParser, Namespace
+from typing import TypeVar, Generic, Sequence, Any
+
+import asyncio
+import shtab
+from rich.console import Console
+
+from .producer.base import BaseScapProducer
+from .queue import ScapChunkQueue, DEFAULT_QUEUE_SIZE, DEFAULT_CHUNK_SIZE
+from .worker.base import BaseScapWorker
+
+from ..cli import DEFAULT_VERBOSITY
+
+
+T = TypeVar("T")
+
+
+class ScapProcessor(Generic[T]):
+
+    item_type_plural = "SCAP items"
+    arg_defaults = {
+        "chunk_size": DEFAULT_CHUNK_SIZE,
+        "queue_size": DEFAULT_QUEUE_SIZE,
+        "verbose": DEFAULT_VERBOSITY,
+    }
+
+    @classmethod
+    def add_args_to_parser(
+        cls,
+        parser: ArgumentParser,
+    ):
+        parser.add_argument(
+            "--chunk-size",
+            help=f"Number of {cls.item_type_plural} to download and process in one request. "
+            "A lower number allows for more frequent updates and feedback. "
+            "Default: %(default)s.",
+            type=int,
+            metavar="N",
+            default=cls.arg_defaults["chunk_size"],
+        )
+        parser.add_argument(
+            "--queue-size",
+            help="Size of the download queue. It sets the maximum number of "
+            f"{cls.item_type_plural} kept in the memory. "
+            "The maximum number of CPEs is chunk size * queue size. "
+            "Default: %(default)s.",
+            type=int,
+            metavar="N",
+            default=cls.arg_defaults["chunk_size"],
+        )
+        parser.add_argument(
+            "-v",
+            "--verbose",
+            action="count",
+            default=cls.arg_defaults["verbose"],
+            help="Enable verbose output.",
+        )
+
+    def __init__(
+        self,
+        console: Console,
+        error_console: Console,
+        producer: BaseScapProducer[T],
+        worker: BaseScapWorker[T],
+        *,
+        queue_size: int | None = None,
+        chunk_size: int | None = None,
+        verbose: int | None = None,
+    ):
+        self.console = console
+        self.error_console = error_console
+        self.producer: BaseScapProducer[T] = producer
+        self.worker: BaseScapWorker[T] = worker
+
+        self.queue: ScapChunkQueue[T] = ScapChunkQueue[T](
+            queue_size=queue_size or self.arg_defaults["queue_size"],
+            chunk_size=chunk_size or self.arg_defaults["chunk_size"],
+        )
+        self.producer.set_queue(self.queue)
+        self.worker.set_queue(self.queue)
+
+        self.verbose = (verbose if not None else self.arg_defaults["verbose"],)
+
+    async def run(self):
+        async with self.producer, self.worker:
+            total_items = await self.producer.fetch_initial_data()
+            if total_items <= 0:
+                return
+
+            async with asyncio.TaskGroup() as tg:
+                producer_task = tg.create_task(self.producer.run_loop())
+                tg.create_task(self.worker.run_loop())
+                await producer_task
+                await self._join()
+
+    async def _join(self):
+        await self.queue.join()

--- a/greenbone/scap/generic_cli/producer/__init__.py
+++ b/greenbone/scap/generic_cli/producer/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2024 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later

--- a/greenbone/scap/generic_cli/producer/base.py
+++ b/greenbone/scap/generic_cli/producer/base.py
@@ -4,7 +4,7 @@
 
 from abc import ABC, abstractmethod
 from argparse import ArgumentParser
-from typing import AsyncContextManager, Generic, TypeVar
+from typing import Any, AsyncContextManager, Generic, TypeVar
 
 from rich.console import Console
 from rich.progress import Progress
@@ -30,10 +30,10 @@ class BaseScapProducer(Generic[T], AsyncContextManager, ABC):
     e.g. `BaseScapProducer[CPE]` will be a producer handling CPE objects.
     """
 
-    _item_type_plural = "SCAP items"
+    _item_type_plural: str = "SCAP items"
     "Plural form of the type of items to use in log messages"
 
-    _arg_defaults = {
+    _arg_defaults: dict[str, Any] = {
         "verbose": DEFAULT_VERBOSITY,
     }
     "Default values for optional arguments."
@@ -79,7 +79,7 @@ class BaseScapProducer(Generic[T], AsyncContextManager, ABC):
         self._verbose = verbose if not None else self._arg_defaults["verbose"]
         "Verbosity level of log messages."
 
-        self._queue: ScapChunkQueue[T] | None = None
+        self._queue: ScapChunkQueue[T]
         "Queue chunks of SCAP items are added to."
 
     @abstractmethod
@@ -110,7 +110,7 @@ class BaseScapProducer(Generic[T], AsyncContextManager, ABC):
         It should also create a task for the `progress` object and update it
         regularly.
         """
-        self._queue.set_producer_finished()
+        pass
 
     def set_queue(self, queue: ScapChunkQueue[T]) -> None:
         """

--- a/greenbone/scap/generic_cli/producer/base.py
+++ b/greenbone/scap/generic_cli/producer/base.py
@@ -1,0 +1,82 @@
+# SPDX-FileCopyrightText: 2024 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from abc import ABC, abstractmethod
+from argparse import ArgumentParser
+
+from pontos.nvd import NVDResults
+from typing import Generic, TypeVar, AsyncContextManager
+
+from rich.console import Console
+from rich.progress import Progress
+
+from greenbone.scap.cli import (
+    DEFAULT_VERBOSITY,
+)
+
+from ..queue import (
+    ScapChunkQueue,
+)
+
+T = TypeVar("T")
+
+
+class BaseScapProducer(Generic[T], AsyncContextManager, ABC):
+
+    item_type_plural = "SCAP items"
+    arg_defaults = {
+        "verbose": DEFAULT_VERBOSITY,
+    }
+
+    @classmethod
+    def add_args_to_parser(cls, parser: ArgumentParser):
+        pass
+
+    def __init__(
+        self,
+        console: Console,
+        error_console: Console,
+        progress: Progress,
+        *,
+        verbose: int | None = None,
+    ):
+        self.console: Console = console
+        self.error_console: Console = error_console
+        self.progress: Progress = progress
+
+        self.verbose = verbose if not None else self.arg_defaults["verbose"]
+
+        self.queue: ScapChunkQueue[T] | None = None
+        self.results: NVDResults[T] | None = None
+
+    @abstractmethod
+    async def fetch_initial_data(
+        self,
+    ) -> int:
+        """
+        Abstract method that must set the `expected_total` in the queue
+        and ensure any remaining initializations of the data source are done,
+        so it can be queried for chunks of SCAP items by `fetch_loop`.
+        :return:
+        """
+        return 0
+
+    @abstractmethod
+    async def run_loop(
+        self,
+    ) -> None:
+        """
+        Abstract method that should fetch chunks of SCAP items and add them
+        to the queue.
+
+        It must also call `set_producer_finished` before returning to signal
+        that no more chunks will be added to the queue.
+
+        It should also create a task for the `progress` object and update it
+        regularly.
+        """
+        self.queue.set_producer_finished()
+
+    def set_queue(self, queue: ScapChunkQueue[T]):
+        self.queue = queue

--- a/greenbone/scap/generic_cli/producer/base.py
+++ b/greenbone/scap/generic_cli/producer/base.py
@@ -4,10 +4,9 @@
 
 from abc import ABC, abstractmethod
 from argparse import ArgumentParser
+from typing import AsyncContextManager, Generic, TypeVar
 
 from pontos.nvd import NVDResults
-from typing import Generic, TypeVar, AsyncContextManager
-
 from rich.console import Console
 from rich.progress import Progress
 
@@ -23,7 +22,6 @@ T = TypeVar("T")
 
 
 class BaseScapProducer(Generic[T], AsyncContextManager, ABC):
-
     item_type_plural = "SCAP items"
     arg_defaults = {
         "verbose": DEFAULT_VERBOSITY,

--- a/greenbone/scap/generic_cli/producer/nvd_api.py
+++ b/greenbone/scap/generic_cli/producer/nvd_api.py
@@ -1,0 +1,233 @@
+# SPDX-FileCopyrightText: 2024 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+from argparse import ArgumentParser, Namespace
+from datetime import datetime
+from pathlib import Path
+
+import httpx
+import stamina
+
+from abc import ABC, abstractmethod
+from typing import Generic, TypeVar, AsyncContextManager
+
+from rich.console import Console
+from rich.progress import Progress
+
+from pontos.nvd import NVDResults, NVDApi
+
+from greenbone.scap.cli import (
+    DEFAULT_RETRIES,
+    DEFAULT_VERBOSITY,
+)
+
+from .base import BaseScapProducer
+from ...timer import Timer
+
+
+T = TypeVar("T")
+
+
+class NvdApiProducer(BaseScapProducer, Generic[T]):
+
+    item_type_plural = BaseScapProducer.item_type_plural
+    arg_defaults = {
+        "retry_attempts": DEFAULT_RETRIES,
+        "verbose": DEFAULT_VERBOSITY,
+    }
+
+    @classmethod
+    def add_args_to_parser(
+        cls,
+        parser: ArgumentParser,
+    ):
+        since_group = parser.add_mutually_exclusive_group()
+        since_group.add_argument(
+            "--since",
+            metavar="DATE",
+            type=datetime.fromisoformat,
+            help="Load all changes since a specific date",
+        )
+        since_group.add_argument(
+            "--since-from-file",
+            type=Path,
+            metavar="FILE",
+            help="Load all changes since a specific date. The date is read from "
+            "FILE.",
+        )
+
+        parser.add_argument(
+            "--number",
+            "-n",
+            metavar="N",
+            help=f"Fetch up to N {cls.item_type_plural} only",
+            type=int,
+        )
+        parser.add_argument(
+            "--start",
+            "-s",
+            metavar="N",
+            help=f"Start at index in the list of {cls.item_type_plural}",
+            type=int,
+        )
+        parser.add_argument(
+            "--retry-attempts",
+            type=int,
+            metavar="N",
+            help="Up to N retries until giving up when HTTP requests are failing. "
+            f"Default: %(default)s",
+            default=cls.arg_defaults["retry_attempts"],
+        )
+        parser.add_argument(
+            "--nvd-api-key",
+            metavar="KEY",
+            help=f"Use a NVD API key for downloading the {cls.item_type_plural}. "
+            "Using an API key allows for downloading with extended rate limits.",
+        )
+
+    @staticmethod
+    def since_from_args(args: Namespace, error_console: Console) -> datetime:
+        if args.since:
+            return args.since
+        elif args.since_from_file:
+            since_from_file = args.since_from_file
+            if since_from_file.exists():
+                return datetime.fromisoformat(
+                    since_from_file.read_text(encoding="utf8").strip()
+                )
+            else:
+                error_console.print(
+                    f"{since_from_file.absolute()} does not exist. Ignoring "
+                    "--since-from-file argument."
+                )
+
+        return None
+
+    def __init__(
+        self,
+        console: Console,
+        error_console: Console,
+        progress: Progress,
+        *,
+        retry_attempts: int,
+        nvd_api_key: str | None = None,
+        request_results: int | None = None,
+        request_filter_opts: dict = {},
+        start_index: int = 0,
+        verbose: int | None = None,
+    ):
+        super().__init__(
+            console,
+            error_console,
+            progress,
+            verbose=verbose,
+        )
+
+        self.retry_attempts: int = retry_attempts
+        self.additional_retry_attempts: int = retry_attempts
+        self.request_results: int = request_results
+        self.request_filter_opts: dict = request_filter_opts
+        self.start_index: int = start_index
+
+        self._nvd_api = self._create_nvd_api(nvd_api_key)
+
+    @abstractmethod
+    def _create_nvd_api(self, nvd_api_key: str) -> NVDApi:
+        pass
+
+    @abstractmethod
+    def _create_nvd_results(self) -> NVDResults[T]:
+        pass
+
+    async def fetch_initial_data(
+        self,
+    ) -> int:
+        """
+        :return: The number of items returned by the initial request
+        """
+        async for attempt in stamina.retry_context(
+            on=httpx.HTTPError,
+            attempts=self.retry_attempts,
+            timeout=None,
+        ):
+            with attempt:
+                attempt_number = attempt.num
+                self.additional_retry_attempts = self.retry_attempts - (
+                    attempt_number - 1
+                )
+                if attempt_number > 1:
+                    self.console.log(
+                        "HTTP request failed. Download attempt "
+                        f"{attempt_number} of {self.retry_attempts}"
+                    )
+                else:
+                    self.console.log(
+                        f"Download attempt {attempt_number} of {self.retry_attempts}"
+                    )
+
+                self.results = await self._create_nvd_results()
+
+        result_count = len(self.results)  # type: ignore
+
+        self.console.log(
+            f"{result_count:,} {self.item_type_plural} to download available"
+        )
+
+        if self.request_results == 0 or not result_count:
+            # no new CPE match strings available or no CPE match strings requested
+            return 0
+
+        total_items = min(self.request_results or result_count, result_count)
+
+        self.queue.total_items = total_items
+        return total_items
+
+    async def run_loop(
+        self,
+    ) -> None:
+        task = self.progress.add_task(
+            f"Downloading {self.item_type_plural}", total=self.queue.total_items
+        )
+
+        try:
+            with Timer() as download_timer:
+                count = 0
+                async for attempt in stamina.retry_context(
+                    on=httpx.HTTPError,
+                    attempts=self.additional_retry_attempts,
+                    timeout=None,
+                ):
+                    with attempt:
+                        attempt_number = attempt.num
+                        if attempt_number > 1:
+                            self.console.log(
+                                "HTTP request failed. Download attempt "
+                                f"{attempt_number} of {self.retry_attempts}"
+                            )
+
+                        async for chunk in self.results.chunks():
+                            count += len(chunk)
+                            self.progress.update(task, completed=count)
+
+                            if self.verbose:
+                                self.console.log(
+                                    f"Downloaded {count:,} of {self.queue.total_items:,} {self.item_type_plural}"
+                                )
+
+                            await self.queue.put_chunk(chunk)
+
+            self.console.log(
+                f"Downloaded {count:,} {self.item_type_plural} in "
+                f"{download_timer.elapsed_time:0.4f} seconds."
+            )
+
+        finally:
+            # signal worker that we are finished with downloading
+            self.queue.set_producer_finished()
+
+    async def __aenter__(self):
+        await self._nvd_api.__aenter__()
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        await self._nvd_api.__aexit__(exc_type, exc_val, exc_tb)

--- a/greenbone/scap/generic_cli/producer/nvd_api.py
+++ b/greenbone/scap/generic_cli/producer/nvd_api.py
@@ -1,35 +1,30 @@
 # SPDX-FileCopyrightText: 2024 Greenbone AG
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
+from abc import abstractmethod
 from argparse import ArgumentParser, Namespace
 from datetime import datetime
 from pathlib import Path
+from typing import Generic, TypeVar
 
 import httpx
 import stamina
-
-from abc import ABC, abstractmethod
-from typing import Generic, TypeVar, AsyncContextManager
-
+from pontos.nvd import NVDApi, NVDResults
 from rich.console import Console
 from rich.progress import Progress
-
-from pontos.nvd import NVDResults, NVDApi
 
 from greenbone.scap.cli import (
     DEFAULT_RETRIES,
     DEFAULT_VERBOSITY,
 )
 
-from .base import BaseScapProducer
 from ...timer import Timer
-
+from .base import BaseScapProducer
 
 T = TypeVar("T")
 
 
 class NvdApiProducer(BaseScapProducer, Generic[T]):
-
     item_type_plural = BaseScapProducer.item_type_plural
     arg_defaults = {
         "retry_attempts": DEFAULT_RETRIES,
@@ -75,7 +70,7 @@ class NvdApiProducer(BaseScapProducer, Generic[T]):
             type=int,
             metavar="N",
             help="Up to N retries until giving up when HTTP requests are failing. "
-            f"Default: %(default)s",
+            "Default: %(default)s",
             default=cls.arg_defaults["retry_attempts"],
         )
         parser.add_argument(
@@ -129,6 +124,7 @@ class NvdApiProducer(BaseScapProducer, Generic[T]):
         self.request_filter_opts: dict = request_filter_opts
         self.start_index: int = start_index
 
+        self._nvd_api_key = nvd_api_key
         self._nvd_api = self._create_nvd_api(nvd_api_key)
 
     @abstractmethod

--- a/greenbone/scap/generic_cli/queue.py
+++ b/greenbone/scap/generic_cli/queue.py
@@ -6,14 +6,32 @@ import asyncio
 from typing import Generic, Sequence, TypeVar
 
 T = TypeVar("T")
+"Generic type variable for the type of SCAP items handled"
 
 DEFAULT_QUEUE_SIZE = 3
+"Default number of chunks allowed in the queue"
+
 DEFAULT_CHUNK_SIZE = 100
+"Default expected maximum number of SCAP items per chunk"
 
 
 class ScapChunkQueue(Generic[T]):
     """
     A queue for passing SCAP data from a producer to a worker processing it.
+
+    Producers should set the expected total number in their
+    (`fetch_initial_data`) method and add new chunks in their main loop
+    (`run_loop`) using `put_chunk`.
+    Once there are no more chunks to be added, the producer must signal this
+    by calling `set_producer_finished`.
+
+    Workers processing the chunks should fetch them inside their `run_loop`
+    with `get_chunk` while more chunks are expected according to
+    `more_chunks_expected` and call `chunk_processed` after processing
+    each chunk.
+
+    The type of the items can be set by the generic type,
+    e.g. `ScapChunkQueue[CPE]` will be a queue handling chunks of CPE objects.
     """
 
     def __init__(
@@ -21,48 +39,70 @@ class ScapChunkQueue(Generic[T]):
         queue_size: int = DEFAULT_QUEUE_SIZE,
         chunk_size: int = DEFAULT_CHUNK_SIZE,
     ):
-        self.queue: asyncio.Queue[Sequence[T]] = asyncio.Queue(queue_size)
+        """
+        Creates a new SCAP chunk queue
+        Args:
+            queue_size: The maximum number of chunks that can be in the queue.
+            chunk_size: The expected number of SCAP items per chunk.
+        """
         self.chunk_size = chunk_size
+        "The expected maximum number of SCAP items per chunk."
 
-        self.producer_finished_event = asyncio.Event()
         self.total_items: int = 1
+        "total_items: The expected total number of SCAP items."
+
+        self._queue: asyncio.Queue[Sequence[T]] = asyncio.Queue(queue_size)
+        "Internal queue data structure for holding the chunks of SCAP items."
+
+        self._producer_finished_event = asyncio.Event()
+        "Event to be set when the producer will no longer add chunks to the queue"
 
     async def put_chunk(self, chunk: Sequence[T]) -> None:
         """
         Adds a chunk of SCAP items to the queue, blocking if the queue is full.
 
-        :param chunk: The chunk (sequence of SCAP items) to put into the queue.
+        Args:
+             chunk: The chunk (sequence of SCAP items) to put into the queue.
         """
-        await self.queue.put(chunk)
+
+        await self._queue.put(chunk)
 
     async def get_chunk(self) -> Sequence[T]:
         """
         Gets and removes the next chunk of SCAP items from the queue,
         blocking if the queue is empty.
 
-        :return: The next chunk (sequence of SCAP items).
+        Returns:
+             The next chunk (sequence of SCAP items).
         """
-        return await self.queue.get()
+        return await self._queue.get()
+
+    def chunk_processed(self) -> None:
+        """
+        Signal that a chunk fetched from the queue has been processed.
+        """
+        self._queue.task_done()
 
     def more_chunks_expected(self) -> bool:
         """
         Checks if more chunks can be fetched, i.e. the "producer finished" event is not set
         and the queue is not empty.
 
-        :return: True if the event is set, False otherwise
+        Returns:
+             True if the event is set, False otherwise
         """
         return not (
-            self.producer_finished_event.is_set() and self.queue.empty()
+            self._producer_finished_event.is_set() and self._queue.empty()
         )
 
-    def set_producer_finished(self):
+    def set_producer_finished(self) -> None:
         """
         Sets the "producer finished" event flag.
         """
-        self.producer_finished_event.set()
+        self._producer_finished_event.set()
 
-    async def join(self):
-        await self.queue.join()
-
-    def task_done(self):
-        self.queue.task_done()
+    async def join(self) -> None:
+        """
+        Blocks until all chunks in the queue are fetched and processed.
+        """
+        await self._queue.join()

--- a/greenbone/scap/generic_cli/queue.py
+++ b/greenbone/scap/generic_cli/queue.py
@@ -1,0 +1,68 @@
+# SPDX-FileCopyrightText: 2024 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import asyncio
+from typing import Generic, Sequence, TypeVar
+
+T = TypeVar("T")
+
+DEFAULT_QUEUE_SIZE = 3
+DEFAULT_CHUNK_SIZE = 100
+
+
+class ScapChunkQueue(Generic[T]):
+    """
+    A queue for passing SCAP data from a producer to a worker processing it.
+    """
+
+    def __init__(
+        self,
+        queue_size: int = DEFAULT_QUEUE_SIZE,
+        chunk_size: int = DEFAULT_CHUNK_SIZE,
+    ):
+        self.queue: asyncio.Queue[Sequence[T]] = asyncio.Queue(queue_size)
+        self.chunk_size = chunk_size
+
+        self.producer_finished_event = asyncio.Event()
+        self.total_items: int = 1
+
+    async def put_chunk(self, chunk: Sequence[T]) -> None:
+        """
+        Adds a chunk of SCAP items to the queue, blocking if the queue is full.
+
+        :param chunk: The chunk (sequence of SCAP items) to put into the queue.
+        """
+        await self.queue.put(chunk)
+
+    async def get_chunk(self) -> Sequence[T]:
+        """
+        Gets and removes the next chunk of SCAP items from the queue,
+        blocking if the queue is empty.
+
+        :return: The next chunk (sequence of SCAP items).
+        """
+        return await self.queue.get()
+
+    def more_chunks_expected(self) -> bool:
+        """
+        Checks if more chunks can be fetched, i.e. the "producer finished" event is not set
+        and the queue is not empty.
+
+        :return: True if the event is set, False otherwise
+        """
+        return not (
+            self.producer_finished_event.is_set() and self.queue.empty()
+        )
+
+    def set_producer_finished(self):
+        """
+        Sets the "producer finished" event flag.
+        """
+        self.producer_finished_event.set()
+
+    async def join(self):
+        await self.queue.join()
+
+    def task_done(self):
+        self.queue.task_done()

--- a/greenbone/scap/generic_cli/worker/__init__.py
+++ b/greenbone/scap/generic_cli/worker/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2024 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later

--- a/greenbone/scap/generic_cli/worker/base.py
+++ b/greenbone/scap/generic_cli/worker/base.py
@@ -1,0 +1,98 @@
+# SPDX-FileCopyrightText: 2024 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import asyncio
+from abc import ABC, abstractmethod
+from argparse import ArgumentParser
+from typing import Generic, TypeVar, Sequence, AsyncContextManager
+
+from rich.console import Console
+from rich.progress import Progress, TaskID
+
+from ..queue import ScapChunkQueue
+
+from ...cli import DEFAULT_VERBOSITY
+from ...errors import ScapError
+
+T = TypeVar("T")
+
+
+class BaseScapWorker(Generic[T], AsyncContextManager, ABC):
+
+    item_type_plural = "SCAP items"
+    arg_defaults = {
+        "verbose": DEFAULT_VERBOSITY,
+    }
+
+    @classmethod
+    def add_args_to_parser(cls, parser: ArgumentParser):
+        pass
+
+    def __init__(
+        self,
+        console: Console,
+        error_console: Console,
+        progress: Progress,
+        *,
+        verbose: int | None = None,
+    ):
+        self.console: Console = console
+        self.error_console: Console = error_console
+        self.progress: Progress = progress
+
+        self.verbose = verbose if not None else self.arg_defaults["verbose"]
+
+        self.queue: ScapChunkQueue[T] | None = None
+        self.task: TaskID | None = None
+        self.processed: int = 0
+
+    @abstractmethod
+    async def add_chunk(self, chunk: Sequence[T]) -> None:
+        pass
+
+    async def loop_start(self) -> None:
+        self.console.log(f"Start processing {self.item_type_plural}")
+        self.task = self.progress.add_task(
+            f"Processing {self.item_type_plural}", total=self.queue.total_items
+        )
+
+    async def loop_step_end(self) -> None:
+        if self.verbose:
+            self.console.log(
+                f"Processed {self.processed:,} of {self.queue.total_items:,} "
+                f"{self.item_type_plural}"
+            )
+
+    async def loop_end(self) -> None:
+        self.console.log(
+            f"Processing of {self.processed:,} {self.item_type_plural} done"
+        )
+
+    async def run_loop(self) -> None:
+
+        await self.loop_start()
+        while self.queue.more_chunks_expected():
+            try:
+                chunk = await self.queue.get_chunk()
+                self.processed += len(chunk)
+
+                if self.task is None:
+                    raise ScapError("Worker progress task is not defined")
+
+                self.progress.update(self.task, completed=self.processed)
+
+                await self.add_chunk(chunk)
+            except asyncio.CancelledError as e:
+                if self.verbose:
+                    self.console.log("Worker has been cancelled")
+                raise e
+
+            self.queue.task_done()
+
+            await self.loop_step_end()
+
+        await self.loop_end()
+
+    def set_queue(self, queue: ScapChunkQueue[T]):
+        self.queue = queue

--- a/greenbone/scap/generic_cli/worker/base.py
+++ b/greenbone/scap/generic_cli/worker/base.py
@@ -5,21 +5,19 @@
 import asyncio
 from abc import ABC, abstractmethod
 from argparse import ArgumentParser
-from typing import Generic, TypeVar, Sequence, AsyncContextManager
+from typing import AsyncContextManager, Generic, Sequence, TypeVar
 
 from rich.console import Console
 from rich.progress import Progress, TaskID
 
-from ..queue import ScapChunkQueue
-
 from ...cli import DEFAULT_VERBOSITY
 from ...errors import ScapError
+from ..queue import ScapChunkQueue
 
 T = TypeVar("T")
 
 
 class BaseScapWorker(Generic[T], AsyncContextManager, ABC):
-
     item_type_plural = "SCAP items"
     arg_defaults = {
         "verbose": DEFAULT_VERBOSITY,
@@ -70,7 +68,6 @@ class BaseScapWorker(Generic[T], AsyncContextManager, ABC):
         )
 
     async def run_loop(self) -> None:
-
         await self.loop_start()
         while self.queue.more_chunks_expected():
             try:

--- a/greenbone/scap/generic_cli/worker/db.py
+++ b/greenbone/scap/generic_cli/worker/db.py
@@ -14,6 +14,7 @@ from ...cli import (
     DEFAULT_POSTGRES_DATABASE_NAME,
     DEFAULT_POSTGRES_HOST,
     DEFAULT_POSTGRES_PORT,
+    DEFAULT_VERBOSITY,
     CLIError,
 )
 from ...db import PostgresDatabase
@@ -45,12 +46,16 @@ class ScapDatabaseWriteWorker(BaseScapWorker[T]):
     """
 
     _item_type_plural = BaseScapWorker._item_type_plural
+    "Plural form of the type of items to use in log messages."
+
     _arg_defaults = {
         "database_name": DEFAULT_POSTGRES_DATABASE_NAME,
         "database_host": DEFAULT_POSTGRES_HOST,
         "database_port": DEFAULT_POSTGRES_PORT,
         "database_schema": None,
+        "verbose": DEFAULT_VERBOSITY,
     }
+    "Default values for optional arguments."
 
     @classmethod
     def add_args_to_parser(
@@ -232,6 +237,7 @@ class ScapDatabaseWriteWorker(BaseScapWorker[T]):
 
     async def __aenter__(self):
         await self._database.__aenter__()
+        await self._manager.__aenter__()
         return self
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):

--- a/greenbone/scap/generic_cli/worker/db.py
+++ b/greenbone/scap/generic_cli/worker/db.py
@@ -1,0 +1,170 @@
+# SPDX-FileCopyrightText: 2024 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import asyncio
+import os
+from argparse import ArgumentParser, Namespace
+from pathlib import Path
+from typing import TypeVar, Sequence, AsyncContextManager
+
+from abc import abstractmethod
+from rich.console import Console
+from rich.progress import Progress
+
+from .base import BaseScapWorker
+from ...cli import (
+    DEFAULT_VERBOSITY,
+    DEFAULT_POSTGRES_DATABASE_NAME,
+    DEFAULT_POSTGRES_HOST,
+    DEFAULT_POSTGRES_PORT,
+    CLIError,
+)
+from ...db import PostgresDatabase
+
+T = TypeVar("T")
+
+
+class ScapDatabaseWriteWorker(BaseScapWorker[T]):
+
+    item_type_plural = BaseScapWorker.item_type_plural
+    arg_defaults = {
+        "database_name": DEFAULT_POSTGRES_DATABASE_NAME,
+        "database_host": DEFAULT_POSTGRES_HOST,
+        "database_port": DEFAULT_POSTGRES_PORT,
+        "database_schema": None,
+    }
+
+    @classmethod
+    def add_args_to_parser(
+        cls: type,
+        parser: ArgumentParser,
+    ):
+        db_group = parser.add_argument_group(
+            title="Database", description="Database related settings"
+        )
+
+        db_group.add_argument(
+            "--database-name",
+            help=f"Name of the {cls.item_type_plural} database. "
+            f"Uses environment variable DATABASE_NAME or "
+            f"\"{cls.arg_defaults['database_name']}\" if not set.",
+        )
+        db_group.add_argument(
+            "--database-host",
+            help=f"Name of the {cls.item_type_plural} database host. "
+            f"Uses environment variable DATABASE_HOST or "
+            f"\"{cls.arg_defaults['database_host']}\" if not set.",
+        )
+
+        try:
+            env_database_port = int(os.environ.get("DATABASE_PORT"))
+        except ValueError:
+            env_database_port = None
+        db_group.add_argument(
+            "--database-port",
+            help=f"Port for the {cls.item_type_plural} database. "
+            f"Uses environment variable DATABASE_PORT or "
+            f"{cls.arg_defaults['database_port']} if not set.",
+            type=int,
+        )
+        db_group.add_argument(
+            "--database-user",
+            help=f"Name of the {cls.item_type_plural} database user. "
+            f"Uses environment variable DATABASE_USER if not set.",
+        )
+        db_group.add_argument(
+            "--database-password",
+            help=f"Name of the {cls.item_type_plural} database password. "
+            f"Uses environment variable DATABASE_PASSWORD if not set.",
+        )
+        db_group.add_argument(
+            "--database-schema",
+            help=f"Name of the {cls.item_type_plural} database schema. "
+            f"Uses environment variable DATABASE_SCHEMA or "
+            f"\"{cls.arg_defaults['database_schema']}\" if not set.",
+        )
+        db_group.add_argument(
+            "--echo-sql",
+            action="store_true",
+            help="Print out all SQL queries.",
+        )
+
+    def __init__(
+        self,
+        console: Console,
+        error_console: Console,
+        progress: Progress,
+        *,
+        database_name: str | None,
+        database_schema: str | None,
+        database_host: str | None,
+        database_port: int | None,
+        database_user: str | None,
+        database_password: str | None,
+        echo_sql: bool = False,
+        verbose: int = arg_defaults,
+    ):
+        super().__init__(console, error_console, progress, verbose=verbose)
+
+        database_name = (
+            database_name
+            or os.environ.get("DATABASE_NAME")
+            or self.arg_defaults["database_name"]
+        )
+        database_schema = (
+            database_schema
+            or os.environ.get("DATABASE_SCHEMA")
+            or self.arg_defaults["database_schema"]
+        )
+        database_host = (
+            database_host
+            or os.environ.get("DATABASE_HOST")
+            or self.arg_defaults["database_host"]
+        )
+        try:
+            env_database_port = int(os.environ.get("DATABASE_PORT"))
+        except TypeError:
+            env_database_port = None
+        database_port = (
+            database_port
+            or env_database_port
+            or self.arg_defaults["database_port"]
+        )
+        database_user = database_user or os.environ.get("DATABASE_USER")
+        database_password = database_password or os.environ.get(
+            "DATABASE_PASSWORD"
+        )
+
+        if not database_user:
+            raise CLIError("Missing user for CPE database")
+
+        if not database_password:
+            raise CLIError("Missing password for CPE database")
+
+        self._database = PostgresDatabase(
+            user=database_user,
+            password=database_password,
+            host=database_host,
+            port=database_port,
+            dbname=database_name,  # type: ignore
+            schema=database_schema,
+            echo=echo_sql,
+        )
+        if verbose:
+            console.log(f"Using PostgreSQL database {database_name}")
+        if verbose >= 2:
+            console.log(
+                f"Database host: {database_host}, port: {database_port}, "
+                f"schema: {database_schema}, user: {database_user}"
+            )
+
+        self._manager = self._create_manager()
+
+    @abstractmethod
+    async def add_chunk(self, chunk: Sequence[T]) -> None:
+        pass
+
+    @abstractmethod
+    def _create_manager(self) -> AsyncContextManager:
+        pass

--- a/greenbone/scap/generic_cli/worker/db.py
+++ b/greenbone/scap/generic_cli/worker/db.py
@@ -5,7 +5,7 @@
 import os
 from abc import abstractmethod
 from argparse import ArgumentParser
-from typing import AsyncContextManager, Sequence, TypeVar
+from typing import AsyncContextManager, Sequence, Type, TypeVar
 
 from rich.console import Console
 from rich.progress import Progress
@@ -59,7 +59,7 @@ class ScapDatabaseWriteWorker(BaseScapWorker[T]):
 
     @classmethod
     def add_args_to_parser(
-        cls: type,
+        cls: Type["ScapDatabaseWriteWorker"],
         parser: ArgumentParser,
     ):
         """
@@ -168,7 +168,8 @@ class ScapDatabaseWriteWorker(BaseScapWorker[T]):
             or self._arg_defaults["database_host"]
         )
         try:
-            env_database_port = int(os.environ.get("DATABASE_PORT"))
+            port_str = os.environ.get("DATABASE_PORT")
+            env_database_port = int(port_str) if port_str else None
         except TypeError:
             env_database_port = None
         database_port = (
@@ -182,11 +183,13 @@ class ScapDatabaseWriteWorker(BaseScapWorker[T]):
         )
 
         if not database_user:
-            raise CLIError(f"Missing user for {self.item_type_plural} database")
+            raise CLIError(
+                f"Missing user for {self._item_type_plural} database"
+            )
 
         if not database_password:
             raise CLIError(
-                f"Missing password for {self.item_type_plural} database"
+                f"Missing password for {self._item_type_plural} database"
             )
 
         self._database = PostgresDatabase(

--- a/greenbone/scap/generic_cli/worker/json.py
+++ b/greenbone/scap/generic_cli/worker/json.py
@@ -2,23 +2,21 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-import asyncio
-from argparse import ArgumentParser, Namespace
+from abc import ABC
+from argparse import ArgumentParser
 from pathlib import Path
-from typing import TypeVar, Sequence, AsyncContextManager
+from typing import TypeVar
 
-from abc import abstractmethod, ABC
 from rich.console import Console
 from rich.progress import Progress
 
-from .base import BaseScapWorker
 from ...cli import DEFAULT_VERBOSITY
+from .base import BaseScapWorker
 
 T = TypeVar("T")
 
 
 class ScapJsonWriteWorker(BaseScapWorker[T], ABC):
-
     item_type_plural = BaseScapWorker.item_type_plural
     arg_defaults = {
         "storage_path": ".",
@@ -34,7 +32,7 @@ class ScapJsonWriteWorker(BaseScapWorker[T], ABC):
         parser.add_argument(
             "--storage-path",
             type=Path,
-            help=f"Directory to write the JSON to. Default: %(default)s",
+            help="Directory to write the JSON to. Default: %(default)s",
             default=cls.arg_defaults["storage_path"],
         )
         parser.add_argument(

--- a/greenbone/scap/generic_cli/worker/json.py
+++ b/greenbone/scap/generic_cli/worker/json.py
@@ -5,7 +5,7 @@
 from abc import ABC
 from argparse import ArgumentParser
 from pathlib import Path
-from typing import TypeVar
+from typing import Type, TypeVar
 
 from rich.console import Console
 from rich.progress import Progress
@@ -38,7 +38,7 @@ class ScapJsonWriteWorker(BaseScapWorker[T], ABC):
 
     @classmethod
     def add_args_to_parser(
-        cls: type,
+        cls: Type["ScapJsonWriteWorker"],
         parser: ArgumentParser,
     ):
         """

--- a/greenbone/scap/generic_cli/worker/json.py
+++ b/greenbone/scap/generic_cli/worker/json.py
@@ -14,26 +14,45 @@ from ...cli import DEFAULT_VERBOSITY
 from .base import BaseScapWorker
 
 T = TypeVar("T")
+"Generic type variable for the type of SCAP items handled"
 
 
 class ScapJsonWriteWorker(BaseScapWorker[T], ABC):
-    item_type_plural = BaseScapWorker.item_type_plural
-    arg_defaults = {
+    """
+    Abstract async context manager base class for a worker writing
+    SCAP items to a single JSON file.
+
+    The type of the SCAP items is to be specified by the generic type,
+    e.g. `ScapJsonWriteWorker[CPE]` will be a producer handling CPE objects.
+    """
+
+    _item_type_plural = BaseScapWorker._item_type_plural
+    "Default values for optional arguments."
+
+    _arg_defaults = {
         "storage_path": ".",
         "schema_path": None,
         "verbose": DEFAULT_VERBOSITY,
     }
+    "Default values for optional arguments."
 
     @classmethod
     def add_args_to_parser(
         cls: type,
         parser: ArgumentParser,
     ):
+        """
+        Class method for adding JSON writer arguments to an
+         `ArgumentParser`.
+
+        Args:
+            parser: The parser to add the arguments to.
+        """
         parser.add_argument(
             "--storage-path",
             type=Path,
             help="Directory to write the JSON to. Default: %(default)s",
-            default=cls.arg_defaults["storage_path"],
+            default=cls._arg_defaults["storage_path"],
         )
         parser.add_argument(
             "--compress",
@@ -43,7 +62,7 @@ class ScapJsonWriteWorker(BaseScapWorker[T], ABC):
         )
         parser.add_argument(
             "--schema-path",
-            default=cls.arg_defaults["schema_path"],
+            default=cls._arg_defaults["schema_path"],
             type=Path,
             help="Json schema file path. Default: %(default)s.",
         )
@@ -59,10 +78,28 @@ class ScapJsonWriteWorker(BaseScapWorker[T], ABC):
         compress: bool = False,
         verbose: int | None = None,
     ):
+        """
+        Constructor for a `ScapJsonWriteWorker`.
+
+        Args:
+            console: Console for standard output.
+            error_console: Console for error output.
+            progress: Progress bar renderer to be updated by the producer.
+            storage_path: Path to the directory to write the JSON file into.
+            schema_path: Optional path to the schema file for JSON validation.
+            compress: Whether to gzip compress the JSON file.
+            verbose: Verbosity level of log messages.
+        """
         super().__init__(console, error_console, progress, verbose=verbose)
+
         self._storage_path = storage_path
+        "Path to the directory to write the JSON file into."
+
         self._schema_path = schema_path
+        "Optional path to the schema file for JSON validation."
+
         self._compress = compress
+        "Whether to gzip compress the JSON file."
 
     async def __aenter__(self):
         return self

--- a/greenbone/scap/generic_cli/worker/json.py
+++ b/greenbone/scap/generic_cli/worker/json.py
@@ -1,0 +1,73 @@
+# SPDX-FileCopyrightText: 2024 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import asyncio
+from argparse import ArgumentParser, Namespace
+from pathlib import Path
+from typing import TypeVar, Sequence, AsyncContextManager
+
+from abc import abstractmethod, ABC
+from rich.console import Console
+from rich.progress import Progress
+
+from .base import BaseScapWorker
+from ...cli import DEFAULT_VERBOSITY
+
+T = TypeVar("T")
+
+
+class ScapJsonWriteWorker(BaseScapWorker[T], ABC):
+
+    item_type_plural = BaseScapWorker.item_type_plural
+    arg_defaults = {
+        "storage_path": ".",
+        "schema_path": None,
+        "verbose": DEFAULT_VERBOSITY,
+    }
+
+    @classmethod
+    def add_args_to_parser(
+        cls: type,
+        parser: ArgumentParser,
+    ):
+        parser.add_argument(
+            "--storage-path",
+            type=Path,
+            help=f"Directory to write the JSON to. Default: %(default)s",
+            default=cls.arg_defaults["storage_path"],
+        )
+        parser.add_argument(
+            "--compress",
+            action="store_true",
+            default=False,
+            help="Gzip compress the resulting JSON file.",
+        )
+        parser.add_argument(
+            "--schema-path",
+            default=cls.arg_defaults["schema_path"],
+            type=Path,
+            help="Json schema file path. Default: %(default)s.",
+        )
+
+    def __init__(
+        self,
+        console: Console,
+        error_console: Console,
+        progress: Progress,
+        *,
+        storage_path: Path,
+        schema_path: Path | None = None,
+        compress: bool = False,
+        verbose: int | None = None,
+    ):
+        super().__init__(console, error_console, progress, verbose=verbose)
+        self._storage_path = storage_path
+        self._schema_path = schema_path
+        self._compress = compress
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        return

--- a/poetry.lock
+++ b/poetry.lock
@@ -2,13 +2,13 @@
 
 [[package]]
 name = "anyio"
-version = "4.6.0"
+version = "4.6.2"
 description = "High level compatibility layer for multiple asynchronous event loop implementations"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.8"
 files = [
-    {file = "anyio-4.6.0-py3-none-any.whl", hash = "sha256:c7d2e9d63e31599eeb636c8c5c03a7e108d73b345f064f1c19fdc87b79036a9a"},
-    {file = "anyio-4.6.0.tar.gz", hash = "sha256:137b4559cbb034c477165047febb6ff83f390fc3b20bf181c1fc0a728cb8beeb"},
+    {file = "anyio-4.6.2-py3-none-any.whl", hash = "sha256:6caec6b1391f6f6d7b2ef2258d2902d36753149f67478f7df4be8e54d03a8f54"},
+    {file = "anyio-4.6.2.tar.gz", hash = "sha256:f72a7bb3dd0752b3bd8b17a844a019d7fbf6ae218c588f4f9ba1b2f600b12347"},
 ]
 
 [package.dependencies]
@@ -17,7 +17,7 @@ sniffio = ">=1.1"
 
 [package.extras]
 doc = ["Sphinx (>=7.4,<8.0)", "packaging", "sphinx-autodoc-typehints (>=1.2.0)", "sphinx-rtd-theme"]
-test = ["anyio[trio]", "coverage[toml] (>=7)", "exceptiongroup (>=1.2.0)", "hypothesis (>=4.0)", "psutil (>=5.9)", "pytest (>=7.0)", "pytest-mock (>=3.6.1)", "trustme", "uvloop (>=0.21.0b1)"]
+test = ["anyio[trio]", "coverage[toml] (>=7)", "exceptiongroup (>=1.2.0)", "hypothesis (>=4.0)", "psutil (>=5.9)", "pytest (>=7.0)", "pytest-mock (>=3.6.1)", "trustme", "truststore (>=0.9.1)", "uvloop (>=0.21.0b1)"]
 trio = ["trio (>=0.26.1)"]
 
 [[package]]
@@ -84,33 +84,33 @@ ruff = ">=0.0.272"
 
 [[package]]
 name = "black"
-version = "24.8.0"
+version = "24.10.0"
 description = "The uncompromising code formatter."
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 files = [
-    {file = "black-24.8.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:09cdeb74d494ec023ded657f7092ba518e8cf78fa8386155e4a03fdcc44679e6"},
-    {file = "black-24.8.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:81c6742da39f33b08e791da38410f32e27d632260e599df7245cccee2064afeb"},
-    {file = "black-24.8.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:707a1ca89221bc8a1a64fb5e15ef39cd755633daa672a9db7498d1c19de66a42"},
-    {file = "black-24.8.0-cp310-cp310-win_amd64.whl", hash = "sha256:d6417535d99c37cee4091a2f24eb2b6d5ec42b144d50f1f2e436d9fe1916fe1a"},
-    {file = "black-24.8.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:fb6e2c0b86bbd43dee042e48059c9ad7830abd5c94b0bc518c0eeec57c3eddc1"},
-    {file = "black-24.8.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:837fd281f1908d0076844bc2b801ad2d369c78c45cf800cad7b61686051041af"},
-    {file = "black-24.8.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:62e8730977f0b77998029da7971fa896ceefa2c4c4933fcd593fa599ecbf97a4"},
-    {file = "black-24.8.0-cp311-cp311-win_amd64.whl", hash = "sha256:72901b4913cbac8972ad911dc4098d5753704d1f3c56e44ae8dce99eecb0e3af"},
-    {file = "black-24.8.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:7c046c1d1eeb7aea9335da62472481d3bbf3fd986e093cffd35f4385c94ae368"},
-    {file = "black-24.8.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:649f6d84ccbae73ab767e206772cc2d7a393a001070a4c814a546afd0d423aed"},
-    {file = "black-24.8.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2b59b250fdba5f9a9cd9d0ece6e6d993d91ce877d121d161e4698af3eb9c1018"},
-    {file = "black-24.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:6e55d30d44bed36593c3163b9bc63bf58b3b30e4611e4d88a0c3c239930ed5b2"},
-    {file = "black-24.8.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:505289f17ceda596658ae81b61ebbe2d9b25aa78067035184ed0a9d855d18afd"},
-    {file = "black-24.8.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:b19c9ad992c7883ad84c9b22aaa73562a16b819c1d8db7a1a1a49fb7ec13c7d2"},
-    {file = "black-24.8.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1f13f7f386f86f8121d76599114bb8c17b69d962137fc70efe56137727c7047e"},
-    {file = "black-24.8.0-cp38-cp38-win_amd64.whl", hash = "sha256:f490dbd59680d809ca31efdae20e634f3fae27fba3ce0ba3208333b713bc3920"},
-    {file = "black-24.8.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:eab4dd44ce80dea27dc69db40dab62d4ca96112f87996bca68cd75639aeb2e4c"},
-    {file = "black-24.8.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:3c4285573d4897a7610054af5a890bde7c65cb466040c5f0c8b732812d7f0e5e"},
-    {file = "black-24.8.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9e84e33b37be070ba135176c123ae52a51f82306def9f7d063ee302ecab2cf47"},
-    {file = "black-24.8.0-cp39-cp39-win_amd64.whl", hash = "sha256:73bbf84ed136e45d451a260c6b73ed674652f90a2b3211d6a35e78054563a9bb"},
-    {file = "black-24.8.0-py3-none-any.whl", hash = "sha256:972085c618ee94f402da1af548a4f218c754ea7e5dc70acb168bfaca4c2542ed"},
-    {file = "black-24.8.0.tar.gz", hash = "sha256:2500945420b6784c38b9ee885af039f5e7471ef284ab03fa35ecdde4688cd83f"},
+    {file = "black-24.10.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e6668650ea4b685440857138e5fe40cde4d652633b1bdffc62933d0db4ed9812"},
+    {file = "black-24.10.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:1c536fcf674217e87b8cc3657b81809d3c085d7bf3ef262ead700da345bfa6ea"},
+    {file = "black-24.10.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:649fff99a20bd06c6f727d2a27f401331dc0cc861fb69cde910fe95b01b5928f"},
+    {file = "black-24.10.0-cp310-cp310-win_amd64.whl", hash = "sha256:fe4d6476887de70546212c99ac9bd803d90b42fc4767f058a0baa895013fbb3e"},
+    {file = "black-24.10.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:5a2221696a8224e335c28816a9d331a6c2ae15a2ee34ec857dcf3e45dbfa99ad"},
+    {file = "black-24.10.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f9da3333530dbcecc1be13e69c250ed8dfa67f43c4005fb537bb426e19200d50"},
+    {file = "black-24.10.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4007b1393d902b48b36958a216c20c4482f601569d19ed1df294a496eb366392"},
+    {file = "black-24.10.0-cp311-cp311-win_amd64.whl", hash = "sha256:394d4ddc64782e51153eadcaaca95144ac4c35e27ef9b0a42e121ae7e57a9175"},
+    {file = "black-24.10.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b5e39e0fae001df40f95bd8cc36b9165c5e2ea88900167bddf258bacef9bbdc3"},
+    {file = "black-24.10.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d37d422772111794b26757c5b55a3eade028aa3fde43121ab7b673d050949d65"},
+    {file = "black-24.10.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:14b3502784f09ce2443830e3133dacf2c0110d45191ed470ecb04d0f5f6fcb0f"},
+    {file = "black-24.10.0-cp312-cp312-win_amd64.whl", hash = "sha256:30d2c30dc5139211dda799758559d1b049f7f14c580c409d6ad925b74a4208a8"},
+    {file = "black-24.10.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:1cbacacb19e922a1d75ef2b6ccaefcd6e93a2c05ede32f06a21386a04cedb981"},
+    {file = "black-24.10.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1f93102e0c5bb3907451063e08b9876dbeac810e7da5a8bfb7aeb5a9ef89066b"},
+    {file = "black-24.10.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ddacb691cdcdf77b96f549cf9591701d8db36b2f19519373d60d31746068dbf2"},
+    {file = "black-24.10.0-cp313-cp313-win_amd64.whl", hash = "sha256:680359d932801c76d2e9c9068d05c6b107f2584b2a5b88831c83962eb9984c1b"},
+    {file = "black-24.10.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:17374989640fbca88b6a448129cd1745c5eb8d9547b464f281b251dd00155ccd"},
+    {file = "black-24.10.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:63f626344343083322233f175aaf372d326de8436f5928c042639a4afbbf1d3f"},
+    {file = "black-24.10.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfa1d0cb6200857f1923b602f978386a3a2758a65b52e0950299ea014be6800"},
+    {file = "black-24.10.0-cp39-cp39-win_amd64.whl", hash = "sha256:2cd9c95431d94adc56600710f8813ee27eea544dd118d45896bb734e9d7a0dc7"},
+    {file = "black-24.10.0-py3-none-any.whl", hash = "sha256:3bb2b7a1f7b685f85b11fed1ef10f8a9148bceb49853e47a294a3dd963c1dd7d"},
+    {file = "black-24.10.0.tar.gz", hash = "sha256:846ea64c97afe3bc677b761787993be4991810ecc7a4a937816dd6bddedc4875"},
 ]
 
 [package.dependencies]
@@ -122,7 +122,7 @@ platformdirs = ">=2"
 
 [package.extras]
 colorama = ["colorama (>=0.4.3)"]
-d = ["aiohttp (>=3.7.4)", "aiohttp (>=3.7.4,!=3.9.0)"]
+d = ["aiohttp (>=3.10)"]
 jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
 uvloop = ["uvloop (>=0.15.2)"]
 
@@ -178,83 +178,73 @@ colorama = {version = "*", markers = "platform_system == \"Windows\""}
 
 [[package]]
 name = "coverage"
-version = "7.6.1"
+version = "7.6.3"
 description = "Code coverage measurement for Python"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 files = [
-    {file = "coverage-7.6.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:b06079abebbc0e89e6163b8e8f0e16270124c154dc6e4a47b413dd538859af16"},
-    {file = "coverage-7.6.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:cf4b19715bccd7ee27b6b120e7e9dd56037b9c0681dcc1adc9ba9db3d417fa36"},
-    {file = "coverage-7.6.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e61c0abb4c85b095a784ef23fdd4aede7a2628478e7baba7c5e3deba61070a02"},
-    {file = "coverage-7.6.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:fd21f6ae3f08b41004dfb433fa895d858f3f5979e7762d052b12aef444e29afc"},
-    {file = "coverage-7.6.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8f59d57baca39b32db42b83b2a7ba6f47ad9c394ec2076b084c3f029b7afca23"},
-    {file = "coverage-7.6.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:a1ac0ae2b8bd743b88ed0502544847c3053d7171a3cff9228af618a068ed9c34"},
-    {file = "coverage-7.6.1-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:e6a08c0be454c3b3beb105c0596ebdc2371fab6bb90c0c0297f4e58fd7e1012c"},
-    {file = "coverage-7.6.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:f5796e664fe802da4f57a168c85359a8fbf3eab5e55cd4e4569fbacecc903959"},
-    {file = "coverage-7.6.1-cp310-cp310-win32.whl", hash = "sha256:7bb65125fcbef8d989fa1dd0e8a060999497629ca5b0efbca209588a73356232"},
-    {file = "coverage-7.6.1-cp310-cp310-win_amd64.whl", hash = "sha256:3115a95daa9bdba70aea750db7b96b37259a81a709223c8448fa97727d546fe0"},
-    {file = "coverage-7.6.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:7dea0889685db8550f839fa202744652e87c60015029ce3f60e006f8c4462c93"},
-    {file = "coverage-7.6.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:ed37bd3c3b063412f7620464a9ac1314d33100329f39799255fb8d3027da50d3"},
-    {file = "coverage-7.6.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d85f5e9a5f8b73e2350097c3756ef7e785f55bd71205defa0bfdaf96c31616ff"},
-    {file = "coverage-7.6.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9bc572be474cafb617672c43fe989d6e48d3c83af02ce8de73fff1c6bb3c198d"},
-    {file = "coverage-7.6.1-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0c0420b573964c760df9e9e86d1a9a622d0d27f417e1a949a8a66dd7bcee7bc6"},
-    {file = "coverage-7.6.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1f4aa8219db826ce6be7099d559f8ec311549bfc4046f7f9fe9b5cea5c581c56"},
-    {file = "coverage-7.6.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:fc5a77d0c516700ebad189b587de289a20a78324bc54baee03dd486f0855d234"},
-    {file = "coverage-7.6.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:b48f312cca9621272ae49008c7f613337c53fadca647d6384cc129d2996d1133"},
-    {file = "coverage-7.6.1-cp311-cp311-win32.whl", hash = "sha256:1125ca0e5fd475cbbba3bb67ae20bd2c23a98fac4e32412883f9bcbaa81c314c"},
-    {file = "coverage-7.6.1-cp311-cp311-win_amd64.whl", hash = "sha256:8ae539519c4c040c5ffd0632784e21b2f03fc1340752af711f33e5be83a9d6c6"},
-    {file = "coverage-7.6.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:95cae0efeb032af8458fc27d191f85d1717b1d4e49f7cb226cf526ff28179778"},
-    {file = "coverage-7.6.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5621a9175cf9d0b0c84c2ef2b12e9f5f5071357c4d2ea6ca1cf01814f45d2391"},
-    {file = "coverage-7.6.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:260933720fdcd75340e7dbe9060655aff3af1f0c5d20f46b57f262ab6c86a5e8"},
-    {file = "coverage-7.6.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:07e2ca0ad381b91350c0ed49d52699b625aab2b44b65e1b4e02fa9df0e92ad2d"},
-    {file = "coverage-7.6.1-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c44fee9975f04b33331cb8eb272827111efc8930cfd582e0320613263ca849ca"},
-    {file = "coverage-7.6.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:877abb17e6339d96bf08e7a622d05095e72b71f8afd8a9fefc82cf30ed944163"},
-    {file = "coverage-7.6.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:3e0cadcf6733c09154b461f1ca72d5416635e5e4ec4e536192180d34ec160f8a"},
-    {file = "coverage-7.6.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:c3c02d12f837d9683e5ab2f3d9844dc57655b92c74e286c262e0fc54213c216d"},
-    {file = "coverage-7.6.1-cp312-cp312-win32.whl", hash = "sha256:e05882b70b87a18d937ca6768ff33cc3f72847cbc4de4491c8e73880766718e5"},
-    {file = "coverage-7.6.1-cp312-cp312-win_amd64.whl", hash = "sha256:b5d7b556859dd85f3a541db6a4e0167b86e7273e1cdc973e5b175166bb634fdb"},
-    {file = "coverage-7.6.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:a4acd025ecc06185ba2b801f2de85546e0b8ac787cf9d3b06e7e2a69f925b106"},
-    {file = "coverage-7.6.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a6d3adcf24b624a7b778533480e32434a39ad8fa30c315208f6d3e5542aeb6e9"},
-    {file = "coverage-7.6.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d0c212c49b6c10e6951362f7c6df3329f04c2b1c28499563d4035d964ab8e08c"},
-    {file = "coverage-7.6.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6e81d7a3e58882450ec4186ca59a3f20a5d4440f25b1cff6f0902ad890e6748a"},
-    {file = "coverage-7.6.1-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:78b260de9790fd81e69401c2dc8b17da47c8038176a79092a89cb2b7d945d060"},
-    {file = "coverage-7.6.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a78d169acd38300060b28d600344a803628c3fd585c912cacc9ea8790fe96862"},
-    {file = "coverage-7.6.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:2c09f4ce52cb99dd7505cd0fc8e0e37c77b87f46bc9c1eb03fe3bc9991085388"},
-    {file = "coverage-7.6.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6878ef48d4227aace338d88c48738a4258213cd7b74fd9a3d4d7582bb1d8a155"},
-    {file = "coverage-7.6.1-cp313-cp313-win32.whl", hash = "sha256:44df346d5215a8c0e360307d46ffaabe0f5d3502c8a1cefd700b34baf31d411a"},
-    {file = "coverage-7.6.1-cp313-cp313-win_amd64.whl", hash = "sha256:8284cf8c0dd272a247bc154eb6c95548722dce90d098c17a883ed36e67cdb129"},
-    {file = "coverage-7.6.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:d3296782ca4eab572a1a4eca686d8bfb00226300dcefdf43faa25b5242ab8a3e"},
-    {file = "coverage-7.6.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:502753043567491d3ff6d08629270127e0c31d4184c4c8d98f92c26f65019962"},
-    {file = "coverage-7.6.1-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6a89ecca80709d4076b95f89f308544ec8f7b4727e8a547913a35f16717856cb"},
-    {file = "coverage-7.6.1-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a318d68e92e80af8b00fa99609796fdbcdfef3629c77c6283566c6f02c6d6704"},
-    {file = "coverage-7.6.1-cp313-cp313t-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:13b0a73a0896988f053e4fbb7de6d93388e6dd292b0d87ee51d106f2c11b465b"},
-    {file = "coverage-7.6.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:4421712dbfc5562150f7554f13dde997a2e932a6b5f352edcce948a815efee6f"},
-    {file = "coverage-7.6.1-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:166811d20dfea725e2e4baa71fffd6c968a958577848d2131f39b60043400223"},
-    {file = "coverage-7.6.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:225667980479a17db1048cb2bf8bfb39b8e5be8f164b8f6628b64f78a72cf9d3"},
-    {file = "coverage-7.6.1-cp313-cp313t-win32.whl", hash = "sha256:170d444ab405852903b7d04ea9ae9b98f98ab6d7e63e1115e82620807519797f"},
-    {file = "coverage-7.6.1-cp313-cp313t-win_amd64.whl", hash = "sha256:b9f222de8cded79c49bf184bdbc06630d4c58eec9459b939b4a690c82ed05657"},
-    {file = "coverage-7.6.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:6db04803b6c7291985a761004e9060b2bca08da6d04f26a7f2294b8623a0c1a0"},
-    {file = "coverage-7.6.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:f1adfc8ac319e1a348af294106bc6a8458a0f1633cc62a1446aebc30c5fa186a"},
-    {file = "coverage-7.6.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a95324a9de9650a729239daea117df21f4b9868ce32e63f8b650ebe6cef5595b"},
-    {file = "coverage-7.6.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b43c03669dc4618ec25270b06ecd3ee4fa94c7f9b3c14bae6571ca00ef98b0d3"},
-    {file = "coverage-7.6.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8929543a7192c13d177b770008bc4e8119f2e1f881d563fc6b6305d2d0ebe9de"},
-    {file = "coverage-7.6.1-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:a09ece4a69cf399510c8ab25e0950d9cf2b42f7b3cb0374f95d2e2ff594478a6"},
-    {file = "coverage-7.6.1-cp38-cp38-musllinux_1_2_i686.whl", hash = "sha256:9054a0754de38d9dbd01a46621636689124d666bad1936d76c0341f7d71bf569"},
-    {file = "coverage-7.6.1-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:0dbde0f4aa9a16fa4d754356a8f2e36296ff4d83994b2c9d8398aa32f222f989"},
-    {file = "coverage-7.6.1-cp38-cp38-win32.whl", hash = "sha256:da511e6ad4f7323ee5702e6633085fb76c2f893aaf8ce4c51a0ba4fc07580ea7"},
-    {file = "coverage-7.6.1-cp38-cp38-win_amd64.whl", hash = "sha256:3f1156e3e8f2872197af3840d8ad307a9dd18e615dc64d9ee41696f287c57ad8"},
-    {file = "coverage-7.6.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:abd5fd0db5f4dc9289408aaf34908072f805ff7792632250dcb36dc591d24255"},
-    {file = "coverage-7.6.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:547f45fa1a93154bd82050a7f3cddbc1a7a4dd2a9bf5cb7d06f4ae29fe94eaf8"},
-    {file = "coverage-7.6.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:645786266c8f18a931b65bfcefdbf6952dd0dea98feee39bd188607a9d307ed2"},
-    {file = "coverage-7.6.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9e0b2df163b8ed01d515807af24f63de04bebcecbd6c3bfeff88385789fdf75a"},
-    {file = "coverage-7.6.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:609b06f178fe8e9f89ef676532760ec0b4deea15e9969bf754b37f7c40326dbc"},
-    {file = "coverage-7.6.1-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:702855feff378050ae4f741045e19a32d57d19f3e0676d589df0575008ea5004"},
-    {file = "coverage-7.6.1-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:2bdb062ea438f22d99cba0d7829c2ef0af1d768d1e4a4f528087224c90b132cb"},
-    {file = "coverage-7.6.1-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:9c56863d44bd1c4fe2abb8a4d6f5371d197f1ac0ebdee542f07f35895fc07f36"},
-    {file = "coverage-7.6.1-cp39-cp39-win32.whl", hash = "sha256:6e2cd258d7d927d09493c8df1ce9174ad01b381d4729a9d8d4e38670ca24774c"},
-    {file = "coverage-7.6.1-cp39-cp39-win_amd64.whl", hash = "sha256:06a737c882bd26d0d6ee7269b20b12f14a8704807a01056c80bb881a4b2ce6ca"},
-    {file = "coverage-7.6.1-pp38.pp39.pp310-none-any.whl", hash = "sha256:e9a6e0eb86070e8ccaedfbd9d38fec54864f3125ab95419970575b42af7541df"},
-    {file = "coverage-7.6.1.tar.gz", hash = "sha256:953510dfb7b12ab69d20135a0662397f077c59b1e6379a768e97c59d852ee51d"},
+    {file = "coverage-7.6.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:6da42bbcec130b188169107ecb6ee7bd7b4c849d24c9370a0c884cf728d8e976"},
+    {file = "coverage-7.6.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c222958f59b0ae091f4535851cbb24eb57fc0baea07ba675af718fb5302dddb2"},
+    {file = "coverage-7.6.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ab84a8b698ad5a6c365b08061920138e7a7dd9a04b6feb09ba1bfae68346ce6d"},
+    {file = "coverage-7.6.3-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:70a6756ce66cd6fe8486c775b30889f0dc4cb20c157aa8c35b45fd7868255c5c"},
+    {file = "coverage-7.6.3-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3c2e6fa98032fec8282f6b27e3f3986c6e05702828380618776ad794e938f53a"},
+    {file = "coverage-7.6.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:921fbe13492caf6a69528f09d5d7c7d518c8d0e7b9f6701b7719715f29a71e6e"},
+    {file = "coverage-7.6.3-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:6d99198203f0b9cb0b5d1c0393859555bc26b548223a769baf7e321a627ed4fc"},
+    {file = "coverage-7.6.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:87cd2e29067ea397a47e352efb13f976eb1b03e18c999270bb50589323294c6e"},
+    {file = "coverage-7.6.3-cp310-cp310-win32.whl", hash = "sha256:a3328c3e64ea4ab12b85999eb0779e6139295bbf5485f69d42cf794309e3d007"},
+    {file = "coverage-7.6.3-cp310-cp310-win_amd64.whl", hash = "sha256:bca4c8abc50d38f9773c1ec80d43f3768df2e8576807d1656016b9d3eeaa96fd"},
+    {file = "coverage-7.6.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:c51ef82302386d686feea1c44dbeef744585da16fcf97deea2a8d6c1556f519b"},
+    {file = "coverage-7.6.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:0ca37993206402c6c35dc717f90d4c8f53568a8b80f0bf1a1b2b334f4d488fba"},
+    {file = "coverage-7.6.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c77326300b839c44c3e5a8fe26c15b7e87b2f32dfd2fc9fee1d13604347c9b38"},
+    {file = "coverage-7.6.3-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6e484e479860e00da1f005cd19d1c5d4a813324e5951319ac3f3eefb497cc549"},
+    {file = "coverage-7.6.3-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0c6c0f4d53ef603397fc894a895b960ecd7d44c727df42a8d500031716d4e8d2"},
+    {file = "coverage-7.6.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:37be7b5ea3ff5b7c4a9db16074dc94523b5f10dd1f3b362a827af66a55198175"},
+    {file = "coverage-7.6.3-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:43b32a06c47539fe275106b376658638b418c7cfdfff0e0259fbf877e845f14b"},
+    {file = "coverage-7.6.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ee77c7bef0724165e795b6b7bf9c4c22a9b8468a6bdb9c6b4281293c6b22a90f"},
+    {file = "coverage-7.6.3-cp311-cp311-win32.whl", hash = "sha256:43517e1f6b19f610a93d8227e47790722c8bf7422e46b365e0469fc3d3563d97"},
+    {file = "coverage-7.6.3-cp311-cp311-win_amd64.whl", hash = "sha256:04f2189716e85ec9192df307f7c255f90e78b6e9863a03223c3b998d24a3c6c6"},
+    {file = "coverage-7.6.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:27bd5f18d8f2879e45724b0ce74f61811639a846ff0e5c0395b7818fae87aec6"},
+    {file = "coverage-7.6.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d546cfa78844b8b9c1c0533de1851569a13f87449897bbc95d698d1d3cb2a30f"},
+    {file = "coverage-7.6.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9975442f2e7a5cfcf87299c26b5a45266ab0696348420049b9b94b2ad3d40234"},
+    {file = "coverage-7.6.3-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:583049c63106c0555e3ae3931edab5669668bbef84c15861421b94e121878d3f"},
+    {file = "coverage-7.6.3-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2341a78ae3a5ed454d524206a3fcb3cec408c2a0c7c2752cd78b606a2ff15af4"},
+    {file = "coverage-7.6.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a4fb91d5f72b7e06a14ff4ae5be625a81cd7e5f869d7a54578fc271d08d58ae3"},
+    {file = "coverage-7.6.3-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:e279f3db904e3b55f520f11f983cc8dc8a4ce9b65f11692d4718ed021ec58b83"},
+    {file = "coverage-7.6.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:aa23ce39661a3e90eea5f99ec59b763b7d655c2cada10729ed920a38bfc2b167"},
+    {file = "coverage-7.6.3-cp312-cp312-win32.whl", hash = "sha256:52ac29cc72ee7e25ace7807249638f94c9b6a862c56b1df015d2b2e388e51dbd"},
+    {file = "coverage-7.6.3-cp312-cp312-win_amd64.whl", hash = "sha256:40e8b1983080439d4802d80b951f4a93d991ef3261f69e81095a66f86cf3c3c6"},
+    {file = "coverage-7.6.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:9134032f5aa445ae591c2ba6991d10136a1f533b1d2fa8f8c21126468c5025c6"},
+    {file = "coverage-7.6.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:99670790f21a96665a35849990b1df447993880bb6463a0a1d757897f30da929"},
+    {file = "coverage-7.6.3-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2dc7d6b380ca76f5e817ac9eef0c3686e7834c8346bef30b041a4ad286449990"},
+    {file = "coverage-7.6.3-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f7b26757b22faf88fcf232f5f0e62f6e0fd9e22a8a5d0d5016888cdfe1f6c1c4"},
+    {file = "coverage-7.6.3-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4c59d6a4a4633fad297f943c03d0d2569867bd5372eb5684befdff8df8522e39"},
+    {file = "coverage-7.6.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f263b18692f8ed52c8de7f40a0751e79015983dbd77b16906e5b310a39d3ca21"},
+    {file = "coverage-7.6.3-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:79644f68a6ff23b251cae1c82b01a0b51bc40c8468ca9585c6c4b1aeee570e0b"},
+    {file = "coverage-7.6.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:71967c35828c9ff94e8c7d405469a1fb68257f686bca7c1ed85ed34e7c2529c4"},
+    {file = "coverage-7.6.3-cp313-cp313-win32.whl", hash = "sha256:e266af4da2c1a4cbc6135a570c64577fd3e6eb204607eaff99d8e9b710003c6f"},
+    {file = "coverage-7.6.3-cp313-cp313-win_amd64.whl", hash = "sha256:ea52bd218d4ba260399a8ae4bb6b577d82adfc4518b93566ce1fddd4a49d1dce"},
+    {file = "coverage-7.6.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:8d4c6ea0f498c7c79111033a290d060c517853a7bcb2f46516f591dab628ddd3"},
+    {file = "coverage-7.6.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:331b200ad03dbaa44151d74daeb7da2cf382db424ab923574f6ecca7d3b30de3"},
+    {file = "coverage-7.6.3-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:54356a76b67cf8a3085818026bb556545ebb8353951923b88292556dfa9f812d"},
+    {file = "coverage-7.6.3-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ebec65f5068e7df2d49466aab9128510c4867e532e07cb6960075b27658dca38"},
+    {file = "coverage-7.6.3-cp313-cp313t-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d33a785ea8354c480515e781554d3be582a86297e41ccbea627a5c632647f2cd"},
+    {file = "coverage-7.6.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:f7ddb920106bbbbcaf2a274d56f46956bf56ecbde210d88061824a95bdd94e92"},
+    {file = "coverage-7.6.3-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:70d24936ca6c15a3bbc91ee9c7fc661132c6f4c9d42a23b31b6686c05073bde5"},
+    {file = "coverage-7.6.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:c30e42ea11badb147f0d2e387115b15e2bd8205a5ad70d6ad79cf37f6ac08c91"},
+    {file = "coverage-7.6.3-cp313-cp313t-win32.whl", hash = "sha256:365defc257c687ce3e7d275f39738dcd230777424117a6c76043459db131dd43"},
+    {file = "coverage-7.6.3-cp313-cp313t-win_amd64.whl", hash = "sha256:23bb63ae3f4c645d2d82fa22697364b0046fbafb6261b258a58587441c5f7bd0"},
+    {file = "coverage-7.6.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:da29ceabe3025a1e5a5aeeb331c5b1af686daab4ff0fb4f83df18b1180ea83e2"},
+    {file = "coverage-7.6.3-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:df8c05a0f574d480947cba11b947dc41b1265d721c3777881da2fb8d3a1ddfba"},
+    {file = "coverage-7.6.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ec1e3b40b82236d100d259854840555469fad4db64f669ab817279eb95cd535c"},
+    {file = "coverage-7.6.3-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b4adeb878a374126f1e5cf03b87f66279f479e01af0e9a654cf6d1509af46c40"},
+    {file = "coverage-7.6.3-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:43d6a66e33b1455b98fc7312b124296dad97a2e191c80320587234a77b1b736e"},
+    {file = "coverage-7.6.3-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:1990b1f4e2c402beb317840030bb9f1b6a363f86e14e21b4212e618acdfce7f6"},
+    {file = "coverage-7.6.3-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:12f9515d875859faedb4144fd38694a761cd2a61ef9603bf887b13956d0bbfbb"},
+    {file = "coverage-7.6.3-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:99ded130555c021d99729fabd4ddb91a6f4cc0707df4b1daf912c7850c373b13"},
+    {file = "coverage-7.6.3-cp39-cp39-win32.whl", hash = "sha256:c3a79f56dee9136084cf84a6c7c4341427ef36e05ae6415bf7d787c96ff5eaa3"},
+    {file = "coverage-7.6.3-cp39-cp39-win_amd64.whl", hash = "sha256:aac7501ae73d4a02f4b7ac8fcb9dc55342ca98ffb9ed9f2dfb8a25d53eda0e4d"},
+    {file = "coverage-7.6.3-pp39.pp310-none-any.whl", hash = "sha256:b9853509b4bf57ba7b1f99b9d866c422c9c5248799ab20e652bbb8a184a38181"},
+    {file = "coverage-7.6.3.tar.gz", hash = "sha256:bb7d5fe92bd0dc235f63ebe9f8c6e0884f7360f88f3411bfed1350c872ef2054"},
 ]
 
 [package.extras]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,9 @@ extend-select = ["I", "PLE", "PLW"]
 greenbone-cve-download = 'greenbone.scap.cve.cli.download:main'
 greenbone-cpe-download = 'greenbone.scap.cpe.cli.download:main'
 greenbone-cpe-find = 'greenbone.scap.cpe.cli.find:main'
+greenbone-cpe-match-db-download = 'greenbone.scap.cpe_match.cli.db_download:main'
+greenbone-cpe-match-json-download = 'greenbone.scap.cpe_match.cli.json_download:main'
+greenbone-cpe-match-find = 'greenbone.scap.cpe_match.cli.find:main'
 
 [tool.mypy]
 files = "greenbone"


### PR DESCRIPTION
## What
Two new CLI tools are added to download CPE match strings from the NVD
API to either a consolidated JSON file or a PostgreSQL database.

These are also based on new generic and modular classes so parts like
the API downloader or the general structure of the JSON and database
writers can be easily reused.

## Why
The new CLI tools are meant to be used for creating a consolidated
CPE match strings file for the feed.

## References
GEA-764
requires greenbone/pontos#1067

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


