### PR TITLE
Change: Reduce memory use of CPE match JSON writer

### DIFF
--- a/greenbone/scap/cpe_match/producer/nvd_api.py
+++ b/greenbone/scap/cpe_match/producer/nvd_api.py
@@ -10,9 +10,9 @@ from rich.console import Console
 from rich.progress import Progress
 
 from greenbone.scap.cli import DEFAULT_RETRIES
+from greenbone.scap.cpe_match.cli.processor import CPE_MATCH_TYPE_PLURAL
 from greenbone.scap.errors import ScapError
 from greenbone.scap.generic_cli.producer.nvd_api import NvdApiProducer
-from greenbone.scap.cpe_match.cli.processor import CPE_MATCH_TYPE_PLURAL
 
 
 class CpeMatchNvdApiProducer(NvdApiProducer[CPEMatchString]):


### PR DESCRIPTION
## What
In the JSON write worker for CPE match strings, the response dict is changed to camelCase keys in place instead of creating a copy in the JsonEncoder.
The modified dict is also serialized to a char array with iterencode instead of using json.dumps().

## Why
These changes reduce the memory usage when creating a JSON file with a large number of match strings.

## References
GEA-820

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


