### PR TITLE
Fix cpe match cli

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -48,7 +48,11 @@ RUN mkdir -p /etc/bash_completion.d && \
     greenbone-cpe-download --print-completion bash > /etc/bash_completion.d/greenbone-cpe-download-complete.bash && \
     echo "source /etc/bash_completion.d/greenbone-cpe-download-complete.bash" >> /etc/bash.bashrc && \
     greenbone-cpe-find --print-completion bash > /etc/bash_completion.d/greenbone-cpe-find-complete.bash && \
-    echo "source /etc/bash_completion.d/greenbone-cpe-find-complete.bash" >> /etc/bash.bashrc
+    echo "source /etc/bash_completion.d/greenbone-cpe-find-complete.bash" >> /etc/bash.bashrc && \
+    greenbone-cpe-match-db-download --print-completion bash > /etc/bash_completion.d/greenbone-cpe-match-db-download.bash && \
+    echo "source /etc/bash_completion.d/greenbone-cpe-match-db-download.bash" >> /etc/bash.bashrc && \
+    greenbone-cpe-match-json-download --print-completion bash > /etc/bash_completion.d/greenbone-cpe-match-json-download.bash && \
+    echo "source /etc/bash_completion.d/greenbone-cpe-match-json-download.bash" >> /etc/bash.bashrc
 
 RUN chown -R greenbone:greenbone /greenbone-scap && \
     chmod 755 /usr/local/bin/entrypoint

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stable-slim as builder
+FROM debian:stable-slim AS builder
 
 COPY . /source
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,6 @@ greenbone-cpe-download = 'greenbone.scap.cpe.cli.download:main'
 greenbone-cpe-find = 'greenbone.scap.cpe.cli.find:main'
 greenbone-cpe-match-db-download = 'greenbone.scap.cpe_match.cli.db_download:main'
 greenbone-cpe-match-json-download = 'greenbone.scap.cpe_match.cli.json_download:main'
-greenbone-cpe-match-find = 'greenbone.scap.cpe_match.cli.find:main'
 
 [tool.mypy]
 files = "greenbone"


### PR DESCRIPTION
## What

Remove non existing `greenbone-cpe-match-find` CLI and add bash completion for the other two cpe-match CLIs to the docker image.

## Why

Using `greenbone-cpe-match-find` will result in an error.