### PR TITLE
Small fixes and tests for CPE matches

### DIFF
--- a/greenbone/scap/cpe_match/producer/nvd_api.py
+++ b/greenbone/scap/cpe_match/producer/nvd_api.py
@@ -51,7 +51,8 @@ class CpeMatchNvdApiProducer(NvdApiProducer[CPEMatchString]):
         request_filter_opts = {}
 
         since = NvdApiProducer.since_from_args(args, error_console)
-        request_filter_opts["last_modified_start_date"] = since
+        if since is not None:
+            request_filter_opts["last_modified_start_date"] = since
 
         return CpeMatchNvdApiProducer(
             console,

--- a/greenbone/scap/data_utils/json.py
+++ b/greenbone/scap/data_utils/json.py
@@ -48,8 +48,9 @@ def convert_keys_to_camel(obj: Any) -> Any:
             # Exclude None values
             if v is not None:
                 new_key = _snake_to_camel(old_key)
-                obj[new_key] = v
-            del obj[old_key]
+                if new_key != old_key:
+                    obj[new_key] = v
+                    del obj[old_key]
     elif isinstance(obj, list):
         for item in obj:
             convert_keys_to_camel(item)

--- a/greenbone/scap/generic_cli/processor.py
+++ b/greenbone/scap/generic_cli/processor.py
@@ -63,7 +63,7 @@ class ScapProcessor(Generic[T]):
             "Default: %(default)s.",
             type=int,
             metavar="N",
-            default=cls._arg_defaults["chunk_size"],
+            default=cls._arg_defaults["queue_size"],
         )
         parser.add_argument(
             "-v",

--- a/tests/cpe_match/__init__.py
+++ b/tests/cpe_match/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2024 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later

--- a/tests/cpe_match/cli/__init__.py
+++ b/tests/cpe_match/cli/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2024 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later

--- a/tests/cpe_match/cli/test_json_download.py
+++ b/tests/cpe_match/cli/test_json_download.py
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: 2024 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import unittest
+from datetime import datetime
+from pathlib import Path
+
+from greenbone.scap.cli import DEFAULT_RETRIES, DEFAULT_VERBOSITY
+from greenbone.scap.cpe_match.cli.json_download import parse_args
+from greenbone.scap.cpe_match.cli.processor import CPE_MATCH_DEFAULT_CHUNK_SIZE
+from greenbone.scap.generic_cli.queue import DEFAULT_QUEUE_SIZE
+
+
+class ParseArgsTestCase(unittest.TestCase):
+    def test_defaults(self):
+        args = parse_args([])
+
+        self.assertIsNone(args.since)
+        self.assertIsNone(args.since_from_file)
+        self.assertIsNone(args.number)
+        self.assertIsNone(args.start)
+        self.assertEqual(DEFAULT_RETRIES, args.retry_attempts)
+        self.assertIsNone(args.nvd_api_key)
+
+        self.assertEqual(Path("."), args.storage_path)
+        self.assertFalse(args.compress)
+
+        self.assertEqual(CPE_MATCH_DEFAULT_CHUNK_SIZE, args.chunk_size)
+        self.assertEqual(DEFAULT_QUEUE_SIZE, args.queue_size)
+        self.assertEqual(DEFAULT_VERBOSITY, args.verbose)
+
+    def test_since(self):
+        args = parse_args(["--since", "2024-12-09"])
+        self.assertEqual(datetime(2024, 12, 9), args.since)
+
+    def test_since_from_file(self):
+        args = parse_args(["--since-from-file", "/tmp/path"])
+        self.assertEqual(Path("/tmp/path"), args.since_from_file)

--- a/tests/cpe_match/producer/__init__.py
+++ b/tests/cpe_match/producer/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2024 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later

--- a/tests/cpe_match/producer/test_nvd_api.py
+++ b/tests/cpe_match/producer/test_nvd_api.py
@@ -1,0 +1,269 @@
+# SPDX-FileCopyrightText: 2024 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import argparse
+import unittest
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+from pontos.testing import temp_file
+from rich.console import Console
+from rich.progress import Progress
+
+from greenbone.scap.cli import DEFAULT_RETRIES, DEFAULT_VERBOSITY
+from greenbone.scap.cpe_match.cli.processor import CpeMatchProcessor
+from greenbone.scap.cpe_match.producer.nvd_api import CpeMatchNvdApiProducer
+
+
+def parse_producer_args(raw_args):
+    parser = argparse.ArgumentParser()
+    CpeMatchProcessor.add_args_to_parser(
+        parser
+    )  # for common args like "verbose"
+    CpeMatchNvdApiProducer.add_args_to_parser(parser)
+    return parser.parse_args(raw_args)
+
+
+class ParseArgsTestCase(unittest.TestCase):
+    @patch(
+        "greenbone.scap.cpe_match.producer.nvd_api.CpeMatchNvdApiProducer",
+        autospec=True,
+    )
+    def test_defaults(self, mock_producer: MagicMock):
+        console = Console(quiet=True)
+        error_console = Console(quiet=True)
+        progress = Progress(disable=True)
+
+        args = parse_producer_args([])
+
+        CpeMatchNvdApiProducer.from_args(args, console, error_console, progress)
+
+        mock_producer.assert_called_once_with(
+            console=console,
+            error_console=error_console,
+            progress=progress,
+            nvd_api_key=None,
+            retry_attempts=DEFAULT_RETRIES,
+            request_results=None,
+            request_filter_opts={},
+            start_index=None,
+            verbose=DEFAULT_VERBOSITY,
+        )
+
+    @patch(
+        "greenbone.scap.cpe_match.producer.nvd_api.CpeMatchNvdApiProducer",
+        autospec=True,
+    )
+    def test_since(self, mock_producer: MagicMock):
+        console = Console(quiet=True)
+        error_console = Console(quiet=True)
+        progress = Progress(disable=True)
+
+        args = parse_producer_args(
+            [
+                "--since",
+                "2024-12-09",
+            ]
+        )
+
+        CpeMatchNvdApiProducer.from_args(args, console, error_console, progress)
+
+        mock_producer.assert_called_once_with(
+            console=console,
+            error_console=error_console,
+            progress=progress,
+            nvd_api_key=None,
+            retry_attempts=DEFAULT_RETRIES,
+            request_results=None,
+            request_filter_opts={
+                "last_modified_start_date": datetime(2024, 12, 9)
+            },
+            start_index=None,
+            verbose=DEFAULT_VERBOSITY,
+        )
+
+    @patch(
+        "greenbone.scap.cpe_match.producer.nvd_api.CpeMatchNvdApiProducer",
+        autospec=True,
+    )
+    def test_since_from_file(self, mock_producer: MagicMock):
+        console = Console(quiet=True)
+        error_console = Console(quiet=True)
+        progress = Progress(disable=True)
+
+        with temp_file("2024-12-05\n", name="since.txt") as temp_file_path:
+            args = parse_producer_args(
+                [
+                    "--since-from-file",
+                    str(temp_file_path),
+                ]
+            )
+
+            CpeMatchNvdApiProducer.from_args(
+                args, console, error_console, progress
+            )
+
+            mock_producer.assert_called_once_with(
+                console=console,
+                error_console=error_console,
+                progress=progress,
+                nvd_api_key=None,
+                retry_attempts=DEFAULT_RETRIES,
+                request_results=None,
+                request_filter_opts={
+                    "last_modified_start_date": datetime(2024, 12, 5)
+                },
+                start_index=None,
+                verbose=DEFAULT_VERBOSITY,
+            )
+
+    @patch(
+        "greenbone.scap.cpe_match.producer.nvd_api.CpeMatchNvdApiProducer",
+        autospec=True,
+    )
+    def test_since_number(self, mock_producer: MagicMock):
+        console = Console(quiet=True)
+        error_console = Console(quiet=True)
+        progress = Progress(disable=True)
+
+        args = parse_producer_args(
+            [
+                "--number",
+                "123",
+            ]
+        )
+
+        CpeMatchNvdApiProducer.from_args(args, console, error_console, progress)
+
+        mock_producer.assert_called_once_with(
+            console=console,
+            error_console=error_console,
+            progress=progress,
+            nvd_api_key=None,
+            retry_attempts=DEFAULT_RETRIES,
+            request_results=123,
+            request_filter_opts={},
+            start_index=None,
+            verbose=DEFAULT_VERBOSITY,
+        )
+
+    @patch(
+        "greenbone.scap.cpe_match.producer.nvd_api.CpeMatchNvdApiProducer",
+        autospec=True,
+    )
+    def test_number(self, mock_producer: MagicMock):
+        console = Console(quiet=True)
+        error_console = Console(quiet=True)
+        progress = Progress(disable=True)
+
+        args = parse_producer_args(
+            [
+                "--number",
+                "123",
+            ]
+        )
+
+        CpeMatchNvdApiProducer.from_args(args, console, error_console, progress)
+
+        mock_producer.assert_called_once_with(
+            console=console,
+            error_console=error_console,
+            progress=progress,
+            nvd_api_key=None,
+            retry_attempts=DEFAULT_RETRIES,
+            request_results=123,
+            request_filter_opts={},
+            start_index=None,
+            verbose=DEFAULT_VERBOSITY,
+        )
+
+    @patch(
+        "greenbone.scap.cpe_match.producer.nvd_api.CpeMatchNvdApiProducer",
+        autospec=True,
+    )
+    def test_start(self, mock_producer: MagicMock):
+        console = Console(quiet=True)
+        error_console = Console(quiet=True)
+        progress = Progress(disable=True)
+
+        args = parse_producer_args(
+            [
+                "--start",
+                "321",
+            ]
+        )
+
+        CpeMatchNvdApiProducer.from_args(args, console, error_console, progress)
+
+        mock_producer.assert_called_once_with(
+            console=console,
+            error_console=error_console,
+            progress=progress,
+            nvd_api_key=None,
+            retry_attempts=DEFAULT_RETRIES,
+            request_results=None,
+            request_filter_opts={},
+            start_index=321,
+            verbose=DEFAULT_VERBOSITY,
+        )
+
+    @patch(
+        "greenbone.scap.cpe_match.producer.nvd_api.CpeMatchNvdApiProducer",
+        autospec=True,
+    )
+    def test_retry_attempts(self, mock_producer: MagicMock):
+        console = Console(quiet=True)
+        error_console = Console(quiet=True)
+        progress = Progress(disable=True)
+
+        args = parse_producer_args(
+            [
+                "--retry-attempts",
+                "7",
+            ]
+        )
+
+        CpeMatchNvdApiProducer.from_args(args, console, error_console, progress)
+
+        mock_producer.assert_called_once_with(
+            console=console,
+            error_console=error_console,
+            progress=progress,
+            nvd_api_key=None,
+            retry_attempts=7,
+            request_results=None,
+            request_filter_opts={},
+            start_index=None,
+            verbose=DEFAULT_VERBOSITY,
+        )
+
+    @patch(
+        "greenbone.scap.cpe_match.producer.nvd_api.CpeMatchNvdApiProducer",
+        autospec=True,
+    )
+    def test_nvd_api_key(self, mock_producer: MagicMock):
+        console = Console(quiet=True)
+        error_console = Console(quiet=True)
+        progress = Progress(disable=True)
+
+        args = parse_producer_args(
+            [
+                "--nvd-api-key",
+                "token123",
+            ]
+        )
+
+        CpeMatchNvdApiProducer.from_args(args, console, error_console, progress)
+
+        mock_producer.assert_called_once_with(
+            console=console,
+            error_console=error_console,
+            progress=progress,
+            nvd_api_key="token123",
+            retry_attempts=DEFAULT_RETRIES,
+            request_results=None,
+            request_filter_opts={},
+            start_index=None,
+            verbose=DEFAULT_VERBOSITY,
+        )

--- a/tests/cpe_match/worker/__init__.py
+++ b/tests/cpe_match/worker/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2024 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later

--- a/tests/cpe_match/worker/mock_producer.py
+++ b/tests/cpe_match/worker/mock_producer.py
@@ -1,0 +1,88 @@
+# SPDX-FileCopyrightText: 2024 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from datetime import datetime
+from uuid import UUID, uuid4
+
+from pontos.nvd.models.cpe_match_string import CPEMatchString
+from rich.console import Console
+from rich.progress import Progress
+
+from greenbone.scap.generic_cli.producer.base import BaseScapProducer
+
+
+def uuid_replace_str(uuid: UUID, iteration: int, number: int) -> str:
+    id_str = str(uuid).rsplit("-", 2)
+    return f"{id_str[0]}-{iteration:04}-{number:012}"
+
+
+def uuid_replace(uuid: UUID, iteration: int, number: int) -> UUID:
+    return UUID(uuid_replace_str(uuid, iteration, number))
+
+
+def generate_cpe_name(iteration: int, number: int) -> str:
+    return f"cpe:2.3:a:acme:test-app:1.{iteration-1}.{number-1}:*:*:*:*:*:*:*"
+
+
+class CpeMatchMockProducer(BaseScapProducer[CPEMatchString]):
+    def __init__(
+        self,
+        console: Console,
+        error_console: Console,
+        progress: Progress,
+        num_chunks: int,
+        chunk_size: int,
+        minimal_cpe_match_strings: bool = False,
+    ):
+        super().__init__(
+            console=console,
+            error_console=error_console,
+            progress=progress,
+        )
+        self.num_chunks: int = num_chunks
+        self.chunk_size: int = chunk_size
+        self.initial_data_fetched: bool = False
+        self.context_entered: bool = False
+        self.context_exited: bool = False
+        self.base_match_criteria_id: UUID = uuid4()
+        self.minimal_cpe_match_strings: bool = minimal_cpe_match_strings
+
+    def generate_chunk(self, chunk_index: int):
+        chunk = []
+        for item_index in range(self.chunk_size):
+            match_criteria_id = uuid_replace(
+                self.base_match_criteria_id, chunk_index, item_index
+            )
+            cpe_name = generate_cpe_name(chunk_index, item_index)
+            now = datetime.now()
+
+            new_cpe_match_string = CPEMatchString(
+                match_criteria_id=match_criteria_id,
+                criteria=cpe_name,
+                status="Active",
+                created=now,
+                last_modified=now,
+                cpe_last_modified=(
+                    None if self.minimal_cpe_match_strings else now
+                ),
+            )
+            chunk.append(new_cpe_match_string)
+
+        return chunk
+
+    async def fetch_initial_data(self) -> int:
+        return self.num_chunks * self.chunk_size
+
+    async def run_loop(self) -> None:
+        try:
+            for chunk_index in range(self.num_chunks):
+                await self._queue.put_chunk(self.generate_chunk(chunk_index))
+        finally:
+            self._queue.set_producer_finished()
+
+    async def __aenter__(self):
+        self.context_entered = True
+
+    async def __aexit__(self, __exc_type, __exc_value, __traceback):
+        self.context_exited = True

--- a/tests/cpe_match/worker/test_db.py
+++ b/tests/cpe_match/worker/test_db.py
@@ -1,0 +1,321 @@
+# SPDX-FileCopyrightText: 2024 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import argparse
+import asyncio
+import unittest
+from unittest import mock
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from rich.console import Console
+from rich.progress import Progress
+
+from greenbone.scap.cli import DEFAULT_VERBOSITY, CLIError
+from greenbone.scap.cpe_match.cli.processor import CpeMatchProcessor
+from greenbone.scap.cpe_match.db.models import CPEMatchStringDatabaseModel
+from greenbone.scap.cpe_match.worker.db import CpeMatchDatabaseWriteWorker
+from tests.cpe_match.worker.mock_producer import CpeMatchMockProducer
+
+
+def parse_worker_args(raw_args):
+    parser = argparse.ArgumentParser()
+    CpeMatchProcessor.add_args_to_parser(
+        parser
+    )  # for common args like "verbose"
+
+    CpeMatchDatabaseWriteWorker.add_args_to_parser(parser)
+    return parser.parse_args(raw_args)
+
+
+class ParseArgsTestCase(unittest.TestCase):
+    @patch(
+        "greenbone.scap.cpe_match.worker.db.CpeMatchDatabaseWriteWorker",
+        autospec=True,
+    )
+    def test_defaults(self, mock_worker_init: MagicMock):
+        console = Console(quiet=True)
+        error_console = Console(quiet=True)
+        progress = Progress(disable=True)
+
+        args = parse_worker_args([])
+        CpeMatchDatabaseWriteWorker.from_args(
+            args, console, error_console, progress
+        )
+
+        mock_worker_init.assert_called_once_with(
+            console=console,
+            error_console=error_console,
+            progress=progress,
+            database_name=None,
+            database_schema=None,
+            database_host=None,
+            database_port=None,
+            database_user=None,
+            database_password=None,
+            echo_sql=False,
+            verbose=DEFAULT_VERBOSITY,
+        )
+
+    @patch(
+        "greenbone.scap.cpe_match.worker.db.CpeMatchDatabaseWriteWorker",
+        autospec=True,
+    )
+    #    @patch("greenbone.scap.db.PostgresDatabase", autospec=True)
+    def test_database(self, mock_worker_init: MagicMock):
+        console = Console(quiet=True)
+        error_console = Console(quiet=True)
+        progress = Progress(disable=True)
+
+        args = parse_worker_args(
+            [
+                "--database-name",
+                "test-db-name",
+                "--database-schema",
+                "test-db-schema",
+                "--database-host",
+                "test-db-host",
+                "--database-port",
+                "12345",
+                "--database-user",
+                "test-db-user",
+                "--database-password",
+                "test-db-password",
+            ]
+        )
+        CpeMatchDatabaseWriteWorker.from_args(
+            args, console, error_console, progress
+        )
+
+        mock_worker_init.assert_called_once_with(
+            console=console,
+            error_console=error_console,
+            progress=progress,
+            database_name="test-db-name",
+            database_schema="test-db-schema",
+            database_host="test-db-host",
+            database_port=12345,
+            database_user="test-db-user",
+            database_password="test-db-password",
+            echo_sql=False,
+            verbose=DEFAULT_VERBOSITY,
+        )
+
+    @patch(
+        "greenbone.scap.cpe_match.worker.db.CpeMatchDatabaseWriteWorker",
+        autospec=True,
+    )
+    def test_echo_sql(self, mock_worker_init: MagicMock):
+        console = Console(quiet=True)
+        error_console = Console(quiet=True)
+        progress = Progress(disable=True)
+
+        args = parse_worker_args(["--echo-sql"])
+        CpeMatchDatabaseWriteWorker.from_args(
+            args, console, error_console, progress
+        )
+
+        mock_worker_init.assert_called_once_with(
+            console=console,
+            error_console=error_console,
+            progress=progress,
+            database_name=None,
+            database_schema=None,
+            database_host=None,
+            database_port=None,
+            database_user=None,
+            database_password=None,
+            echo_sql=True,
+            verbose=DEFAULT_VERBOSITY,
+        )
+
+
+class InitTestCase(unittest.TestCase):
+    def test_missing_user(self):
+        console = Console(quiet=True)
+        error_console = Console(quiet=True)
+        progress = Progress(disable=True)
+
+        with self.assertRaises(CLIError):
+            CpeMatchDatabaseWriteWorker(
+                console=console,
+                error_console=error_console,
+                progress=progress,
+                database_name=None,
+                database_schema=None,
+                database_host=None,
+                database_port=None,
+                database_user=None,
+                database_password=None,
+            )
+
+    def test_missing_password(self):
+        console = Console(quiet=True)
+        error_console = Console(quiet=True)
+        progress = Progress(disable=True)
+
+        with self.assertRaises(CLIError):
+            CpeMatchDatabaseWriteWorker(
+                console=console,
+                error_console=error_console,
+                progress=progress,
+                database_name=None,
+                database_schema=None,
+                database_host=None,
+                database_port=None,
+                database_user="db-test-user",
+                database_password=None,
+            )
+
+    @patch(
+        "greenbone.scap.generic_cli.worker.db.PostgresDatabase", autospec=True
+    )
+    def test_database_defaults(self, db_mock: MagicMock):
+        console = Console(quiet=True)
+        error_console = Console(quiet=True)
+        progress = Progress(disable=True)
+
+        CpeMatchDatabaseWriteWorker(
+            console=console,
+            error_console=error_console,
+            progress=progress,
+            database_name=None,
+            database_schema=None,
+            database_host=None,
+            database_port=None,
+            database_user="db-test-user",
+            database_password="db-test-password",
+        )
+
+        db_mock.assert_called_with(
+            user="db-test-user",
+            password="db-test-password",
+            host="localhost",
+            port=5432,
+            dbname="scap",
+            schema=None,
+            echo=False,
+        )
+
+    @patch(
+        "greenbone.scap.generic_cli.worker.db.PostgresDatabase", autospec=True
+    )
+    def test_database_custom(self, db_mock: MagicMock):
+        console = Console(quiet=True)
+        error_console = Console(quiet=True)
+        progress = Progress(disable=True)
+
+        CpeMatchDatabaseWriteWorker(
+            console=console,
+            error_console=error_console,
+            progress=progress,
+            database_name="db-test-name",
+            database_schema="db-test-schema",
+            database_host="db-test-host",
+            database_port=12345,
+            database_user="db-test-user",
+            database_password="db-test-password",
+        )
+
+        db_mock.assert_called_with(
+            user="db-test-user",
+            password="db-test-password",
+            host="db-test-host",
+            port=12345,
+            dbname="db-test-name",
+            schema="db-test-schema",
+            echo=False,
+        )
+
+    @patch(
+        "greenbone.scap.generic_cli.worker.db.PostgresDatabase", autospec=True
+    )
+    def test_echo_sql(self, db_mock: MagicMock):
+        console = Console()
+        error_console = Console()
+        progress = Progress()
+
+        CpeMatchDatabaseWriteWorker(
+            console=console,
+            error_console=error_console,
+            progress=progress,
+            database_name=None,
+            database_schema=None,
+            database_host=None,
+            database_port=None,
+            database_user="db-test-user",
+            database_password="db-test-password",
+            echo_sql=True,
+        )
+
+        db_mock.assert_called_with(
+            user="db-test-user",
+            password="db-test-password",
+            host="localhost",
+            port=5432,
+            dbname="scap",
+            schema=None,
+            echo=True,
+        )
+
+
+class WriteTestCase(unittest.IsolatedAsyncioTestCase):
+    NUM_CHUNKS = 5
+    CHUNK_SIZE = 3
+    QUEUE_SIZE = 2
+
+    @patch(
+        "greenbone.scap.generic_cli.worker.db.PostgresDatabase", autospec=True
+    )
+    async def test_write_json(self, db_mock: AsyncMock):
+        console = Console(quiet=False)
+        error_console = Console(quiet=False)
+        progress = Progress(disable=True)
+
+        producer = CpeMatchMockProducer(
+            console=console,
+            error_console=error_console,
+            progress=progress,
+            num_chunks=self.NUM_CHUNKS,
+            chunk_size=self.CHUNK_SIZE,
+        )
+        worker = CpeMatchDatabaseWriteWorker(
+            console=console,
+            error_console=error_console,
+            progress=progress,
+            database_name="test-db-name",
+            database_schema="test-db-name",
+            database_host="test-db-host",
+            database_port=12345,
+            database_user="test-db-user",
+            database_password="test-db-password",
+        )
+        processor = CpeMatchProcessor(
+            console,
+            error_console,
+            producer,
+            worker,
+            queue_size=self.QUEUE_SIZE,
+            chunk_size=self.CHUNK_SIZE,
+        )
+        db_mock.insert.side_effect = lambda x: print("x=", x)
+
+        async with asyncio.timeout(10):
+            await processor.run()
+
+            db_mock.assert_called_once_with(
+                dbname="test-db-name",
+                schema="test-db-name",
+                host="test-db-host",
+                port=12345,
+                user="test-db-user",
+                password="test-db-password",
+                echo=False,
+            )
+            # check if there is at least one insert call for each chunk
+            insert_call = mock.call().insert(CPEMatchStringDatabaseModel)
+            self.assertGreaterEqual(
+                self.NUM_CHUNKS, db_mock.mock_calls.count(insert_call)
+            )
+
+            print(db_mock)

--- a/tests/cpe_match/worker/test_db.py
+++ b/tests/cpe_match/worker/test_db.py
@@ -268,8 +268,8 @@ class WriteTestCase(unittest.IsolatedAsyncioTestCase):
         "greenbone.scap.generic_cli.worker.db.PostgresDatabase", autospec=True
     )
     async def test_write_json(self, db_mock: AsyncMock):
-        console = Console(quiet=False)
-        error_console = Console(quiet=False)
+        console = Console(quiet=True)
+        error_console = Console(quiet=True)
         progress = Progress(disable=True)
 
         producer = CpeMatchMockProducer(
@@ -317,5 +317,3 @@ class WriteTestCase(unittest.IsolatedAsyncioTestCase):
             self.assertGreaterEqual(
                 self.NUM_CHUNKS, db_mock.mock_calls.count(insert_call)
             )
-
-            print(db_mock)

--- a/tests/cpe_match/worker/test_json.py
+++ b/tests/cpe_match/worker/test_json.py
@@ -1,0 +1,238 @@
+# SPDX-FileCopyrightText: 2024 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import argparse
+import asyncio
+import json
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from pontos.testing import temp_directory
+from rich.console import Console
+from rich.progress import Progress
+
+from greenbone.scap.cli import DEFAULT_VERBOSITY
+from greenbone.scap.cpe_match.cli.processor import CpeMatchProcessor
+from greenbone.scap.cpe_match.worker.json import CpeMatchJsonWriteWorker
+from tests.cpe_match.worker.mock_producer import CpeMatchMockProducer
+
+
+def parse_worker_args(raw_args):
+    parser = argparse.ArgumentParser()
+    CpeMatchProcessor.add_args_to_parser(
+        parser
+    )  # for common args like "verbose"
+
+    CpeMatchJsonWriteWorker.add_args_to_parser(parser)
+    return parser.parse_args(raw_args)
+
+
+class ParseArgsTestCase(unittest.TestCase):
+    @patch(
+        "greenbone.scap.cpe_match.worker.json.CpeMatchJsonWriteWorker",
+        autospec=True,
+    )
+    def test_defaults(self, mock_worker: MagicMock):
+        console = Console()
+        error_console = Console()
+        progress = Progress()
+
+        args = parse_worker_args([])
+        CpeMatchJsonWriteWorker.from_args(
+            args, console, error_console, progress
+        )
+
+        mock_worker.assert_called_once_with(
+            console=console,
+            error_console=error_console,
+            progress=progress,
+            storage_path=Path("."),
+            schema_path=None,
+            compress=False,
+            verbose=DEFAULT_VERBOSITY,
+        )
+
+    @patch(
+        "greenbone.scap.cpe_match.worker.json.CpeMatchJsonWriteWorker",
+        autospec=True,
+    )
+    def test_storage_path(self, mock_worker: MagicMock):
+        console = Console()
+        error_console = Console()
+        progress = Progress()
+
+        args = parse_worker_args(["--storage-path", "/tmp/test"])
+        CpeMatchJsonWriteWorker.from_args(
+            args, console, error_console, progress
+        )
+
+        mock_worker.assert_called_once_with(
+            console=console,
+            error_console=error_console,
+            progress=progress,
+            storage_path=Path("/tmp/test"),
+            schema_path=None,
+            compress=False,
+            verbose=DEFAULT_VERBOSITY,
+        )
+
+    @patch(
+        "greenbone.scap.cpe_match.worker.json.CpeMatchJsonWriteWorker",
+        autospec=True,
+    )
+    def test_schema_path(self, mock_worker: MagicMock):
+        console = Console()
+        error_console = Console()
+        progress = Progress()
+
+        args = parse_worker_args(["--schema-path", "/tmp/test"])
+        CpeMatchJsonWriteWorker.from_args(
+            args, console, error_console, progress
+        )
+
+        mock_worker.assert_called_once_with(
+            console=console,
+            error_console=error_console,
+            progress=progress,
+            storage_path=Path("."),
+            schema_path=Path("/tmp/test"),
+            compress=False,
+            verbose=DEFAULT_VERBOSITY,
+        )
+
+    @patch(
+        "greenbone.scap.cpe_match.worker.json.CpeMatchJsonWriteWorker",
+        autospec=True,
+    )
+    def test_compress(self, mock_worker: MagicMock):
+        console = Console()
+        error_console = Console()
+        progress = Progress()
+
+        args = parse_worker_args(["--compress"])
+        CpeMatchJsonWriteWorker.from_args(
+            args, console, error_console, progress
+        )
+
+        mock_worker.assert_called_once_with(
+            console=console,
+            error_console=error_console,
+            progress=progress,
+            storage_path=Path("."),
+            schema_path=None,
+            compress=True,
+            verbose=DEFAULT_VERBOSITY,
+        )
+
+
+class WriteTestCase(unittest.IsolatedAsyncioTestCase):
+    NUM_CHUNKS = 5
+    CHUNK_SIZE = 3
+    QUEUE_SIZE = 2
+
+    async def test_write_json(self):
+        console = Console(quiet=True)
+        error_console = Console(quiet=True)
+        progress = Progress(disable=True)
+
+        with temp_directory() as temp_storage_path:
+            producer = CpeMatchMockProducer(
+                console=console,
+                error_console=error_console,
+                progress=progress,
+                num_chunks=self.NUM_CHUNKS,
+                chunk_size=self.CHUNK_SIZE,
+            )
+            worker = CpeMatchJsonWriteWorker(
+                console=console,
+                error_console=error_console,
+                progress=progress,
+                storage_path=temp_storage_path,
+            )
+            processor = CpeMatchProcessor(
+                console,
+                error_console,
+                producer,
+                worker,
+                queue_size=self.QUEUE_SIZE,
+                chunk_size=self.CHUNK_SIZE,
+            )
+            async with asyncio.timeout(10):
+                await processor.run()
+
+            temp_file_path: Path = temp_storage_path / "nvd-cpe-matches.json"
+            self.assertTrue(temp_file_path.exists())
+            with open(temp_file_path) as fp:
+                parsed_json = json.load(fp)
+            self.assertEqual(parsed_json.get("resultsPerPage"), 15)
+            self.assertEqual(parsed_json.get("totalResults"), 15)
+            self.assertIsNotNone(parsed_json.get("timestamp"))
+            self.assertNotEqual("", parsed_json.get("timestamp"))
+
+            match_strings = parsed_json.get("matchStrings")
+            self.assertEqual(
+                self.CHUNK_SIZE * self.NUM_CHUNKS, len(match_strings)
+            )
+            for match_string_item in match_strings:
+                match_string = match_string_item.get("matchString")
+                self.assertIsNotNone(match_string)
+                self.assertIn("matchCriteriaId", match_string)
+                self.assertIn("criteria", match_string)
+                self.assertIn("created", match_string)
+                self.assertIn("lastModified", match_string)
+                self.assertIn("cpeLastModified", match_string)
+
+    async def test_write_json_minimal(self):
+        console = Console(quiet=True)
+        error_console = Console(quiet=True)
+        progress = Progress(disable=True)
+
+        with temp_directory() as temp_storage_path:
+            producer = CpeMatchMockProducer(
+                console=console,
+                error_console=error_console,
+                progress=progress,
+                num_chunks=self.NUM_CHUNKS,
+                chunk_size=self.CHUNK_SIZE,
+                minimal_cpe_match_strings=True,
+            )
+            worker = CpeMatchJsonWriteWorker(
+                console=console,
+                error_console=error_console,
+                progress=progress,
+                storage_path=temp_storage_path,
+            )
+            processor = CpeMatchProcessor(
+                console,
+                error_console,
+                producer,
+                worker,
+                queue_size=self.QUEUE_SIZE,
+                chunk_size=self.CHUNK_SIZE,
+            )
+            async with asyncio.timeout(10):
+                await processor.run()
+
+            temp_file_path: Path = temp_storage_path / "nvd-cpe-matches.json"
+            self.assertTrue(temp_file_path.exists())
+            with open(temp_file_path) as fp:
+                parsed_json = json.load(fp)
+            self.assertEqual(parsed_json.get("resultsPerPage"), 15)
+            self.assertEqual(parsed_json.get("totalResults"), 15)
+            self.assertIsNotNone(parsed_json.get("timestamp"))
+            self.assertNotEqual("", parsed_json.get("timestamp"))
+
+            match_strings = parsed_json.get("matchStrings")
+            self.assertEqual(
+                self.CHUNK_SIZE * self.NUM_CHUNKS, len(match_strings)
+            )
+            for match_string_item in match_strings:
+                match_string = match_string_item.get("matchString")
+                self.assertIsNotNone(match_string)
+                self.assertIn("matchCriteriaId", match_string)
+                self.assertIn("criteria", match_string)
+                self.assertIn("created", match_string)
+                self.assertIn("lastModified", match_string)
+                self.assertNotIn("cpeLastModified", match_string)

--- a/tests/cpe_match/worker/test_json.py
+++ b/tests/cpe_match/worker/test_json.py
@@ -162,7 +162,7 @@ class WriteTestCase(unittest.IsolatedAsyncioTestCase):
             async with asyncio.timeout(10):
                 await processor.run()
 
-            temp_file_path: Path = temp_storage_path / "nvd-cpe-matches.json"
+            temp_file_path: Path = temp_storage_path / "nvd_cpe_matches.json"
             self.assertTrue(temp_file_path.exists())
             with open(temp_file_path) as fp:
                 parsed_json = json.load(fp)
@@ -215,7 +215,7 @@ class WriteTestCase(unittest.IsolatedAsyncioTestCase):
             async with asyncio.timeout(10):
                 await processor.run()
 
-            temp_file_path: Path = temp_storage_path / "nvd-cpe-matches.json"
+            temp_file_path: Path = temp_storage_path / "nvd_cpe_matches.json"
             self.assertTrue(temp_file_path.exists())
             with open(temp_file_path) as fp:
                 parsed_json = json.load(fp)


### PR DESCRIPTION
## What
- Added tests for the CPE match CLI classes
- ScapProcessor now uses the correct default queue size
- request_filter_opts are not updated if since is None
- CPE match caching no longer erroneously removes keys where snake_case and camelCase are the same

## Why

<!-- Describe why are these changes necessary? -->

## References

GEA-790

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


