### PR TITLE
Add: Script for creating CPE match JSON from database

### DIFF
--- a/greenbone/scap/cpe_match/cli/db_to_json.py
+++ b/greenbone/scap/cpe_match/cli/db_to_json.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-import tracemalloc
 from argparse import ArgumentParser, Namespace
 from typing import Sequence
 
@@ -12,8 +11,7 @@ from rich.progress import Progress
 from greenbone.scap.cli import CLIRunner
 from greenbone.scap.cpe_match.cli.processor import CpeMatchProcessor
 from greenbone.scap.cpe_match.producer.db import CpeMatchDatabaseProducer
-
-from ..worker.json import CpeMatchJsonWriteWorker
+from greenbone.scap.cpe_match.worker.json import CpeMatchJsonWriteWorker
 
 
 def parse_args(args: Sequence[str] | None = None) -> Namespace:
@@ -36,7 +34,6 @@ def parse_args(args: Sequence[str] | None = None) -> Namespace:
 async def download(console, error_console) -> None:
     args = parse_args()
 
-    tracemalloc.start()
     with Progress(console=console) as progress:
         producer = CpeMatchDatabaseProducer.from_args(
             args,
@@ -61,7 +58,6 @@ async def download(console, error_console) -> None:
         )
 
         await processor.run()
-        print(f"tracemalloc {tracemalloc.get_traced_memory()}")
 
 
 def main() -> None:

--- a/greenbone/scap/cpe_match/cli/db_to_json.py
+++ b/greenbone/scap/cpe_match/cli/db_to_json.py
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: 2025 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import tracemalloc
+from argparse import ArgumentParser, Namespace
+from typing import Sequence
+
+import shtab
+from rich.progress import Progress
+
+from greenbone.scap.cli import CLIRunner
+from greenbone.scap.cpe_match.cli.processor import CpeMatchProcessor
+from greenbone.scap.cpe_match.producer.db import CpeMatchDatabaseProducer
+
+from ..worker.json import CpeMatchJsonWriteWorker
+
+
+def parse_args(args: Sequence[str] | None = None) -> Namespace:
+    parser = ArgumentParser(
+        description="Write CPE match strings from a database to a JSON file. "
+        "Queries CPE match string information from a database "
+        "and consolidates it into a single JSON file."
+    )
+    shtab.add_argument_to(parser)
+
+    CpeMatchDatabaseProducer.add_args_to_parser(parser)
+
+    CpeMatchJsonWriteWorker.add_args_to_parser(parser)
+
+    CpeMatchProcessor.add_args_to_parser(parser)
+
+    return parser.parse_args(args)
+
+
+async def download(console, error_console) -> None:
+    args = parse_args()
+
+    tracemalloc.start()
+    with Progress(console=console) as progress:
+        producer = CpeMatchDatabaseProducer.from_args(
+            args,
+            console,
+            error_console,
+            progress,
+        )
+
+        worker = CpeMatchJsonWriteWorker.from_args(
+            args,
+            console,
+            error_console,
+            progress,
+        )
+
+        processor = CpeMatchProcessor.from_args(
+            args,
+            console,
+            error_console,
+            producer,
+            worker,
+        )
+
+        await processor.run()
+        print(f"tracemalloc {tracemalloc.get_traced_memory()}")
+
+
+def main() -> None:
+    CLIRunner.run(download)
+
+
+if __name__ == "__main__":
+    main()

--- a/greenbone/scap/cpe_match/db/manager.py
+++ b/greenbone/scap/cpe_match/db/manager.py
@@ -218,7 +218,7 @@ class CPEMatchStringDatabaseManager(AsyncContextManager):
     async def count(
         self,
         *,
-        match_criteria_id: str | None,
+        match_criteria_id: str | None = None,
         last_modification_start_date: datetime | None = None,
         last_modification_end_date: datetime | None = None,
         created_start_date: datetime | None = None,

--- a/greenbone/scap/cpe_match/producer/db.py
+++ b/greenbone/scap/cpe_match/producer/db.py
@@ -1,0 +1,195 @@
+# SPDX-FileCopyrightText: 2024 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from argparse import Namespace
+from typing import AsyncIterator
+from uuid import UUID
+
+from pontos.nvd.models.cpe_match_string import CPEMatch, CPEMatchString
+from rich.console import Console
+from rich.progress import Progress
+
+from greenbone.scap.cli import DEFAULT_VERBOSITY
+from greenbone.scap.cpe_match.cli.processor import CPE_MATCH_TYPE_PLURAL
+from greenbone.scap.cpe_match.db.manager import CPEMatchStringDatabaseManager
+from greenbone.scap.cpe_match.db.models import (
+    BaseDatabaseModel,
+    CPEMatchStringDatabaseModel,
+)
+from greenbone.scap.errors import ScapError
+from greenbone.scap.generic_cli.producer.db import DatabaseProducer
+
+
+class CpeMatchDatabaseProducer(DatabaseProducer[CPEMatchString]):
+    """
+    Async context manager class for a producer querying
+    CPE match strings from a database.
+    """
+
+    _item_type_plural = CPE_MATCH_TYPE_PLURAL
+    "Plural form of the type of items to use in log messages"
+
+    _arg_defaults = DatabaseProducer._arg_defaults
+    "Default values for optional arguments."
+
+    @classmethod
+    def from_args(
+        cls,
+        args: Namespace,
+        console: Console,
+        error_console: Console,
+        progress: Progress,
+    ) -> "CpeMatchDatabaseProducer":
+        """
+        Create a new `CPEMatchDatabaseProducer` with parameters from
+         the given command line args gathered by an `ArgumentParser`.
+
+        Args:
+            args: Command line arguments to use
+            console: Console for standard output.
+            error_console: Console for error output.
+            progress: Progress bar renderer to be updated by the producer.
+
+        Returns:
+            The new `CpeMatchDatabaseProducer`.
+        """
+        return CpeMatchDatabaseProducer(
+            console,
+            error_console,
+            progress,
+            database_name=args.database_name,
+            database_schema=args.database_schema,
+            database_host=args.database_host,
+            database_port=args.database_port,
+            database_user=args.database_user,
+            database_password=args.database_password,
+            echo_sql=args.echo_sql,
+            verbose=args.verbose or 0,
+        )
+
+    def __init__(
+        self,
+        console: Console,
+        error_console: Console,
+        progress: Progress,
+        *,
+        database_name: str,
+        database_schema: str,
+        database_host: str,
+        database_port: int,
+        database_user: str,
+        database_password: str,
+        echo_sql: bool = False,
+        verbose: int = DEFAULT_VERBOSITY,
+    ):
+        """
+        Constructor for a CPE match string database producer.
+
+        If the `database_...` arguments are None or not given, corresponding
+        environment variables will be tried next before finally using the
+        defaults as a fallback.
+
+        Args:
+            console: Console for standard output.
+            error_console: Console for error output.
+            progress: Progress bar renderer to be updated by the producer.
+            database_name: Name of the database to use.
+            database_schema: Optional database schema to use.
+            database_host: IP address or hostname of the database server to use.
+            database_port: Port of the database server to use.
+            database_user: Name of the database user to use.
+            database_password: Password of the database user to use.
+            echo_sql: Whether to print SQL statements.
+            verbose: Verbosity level of log messages.
+        """
+        self._manager: CPEMatchStringDatabaseManager
+
+        super().__init__(
+            console,
+            error_console,
+            progress,
+            database_name=database_name,
+            database_schema=database_schema,
+            database_host=database_host,
+            database_port=database_port,
+            database_user=database_user,
+            database_password=database_password,
+            echo_sql=echo_sql,
+            verbose=verbose,
+        )
+
+    def _create_manager(self) -> CPEMatchStringDatabaseManager:
+        """
+        Callback creating a new database manager for handling CPE match strings.
+
+        Returns: The new database manager.
+        """
+        return CPEMatchStringDatabaseManager(self._database)
+
+    def _convert_db_model(self, db_model: BaseDatabaseModel) -> CPEMatchString:
+        """
+        Callback converting a CPE match string database model to a Pontos model.
+
+        Args:
+            db_model: The database model convert
+
+        Returns:
+            The converted model object.
+        """
+        if not isinstance(db_model, CPEMatchStringDatabaseModel):
+            raise ScapError(
+                f"DB model is not a CPEMatchDatabaseModel: {db_model}"
+            )
+        match_string_db_model: CPEMatchStringDatabaseModel = db_model
+
+        if not match_string_db_model.match_criteria_id:
+            raise ScapError(f"Missing match_criteria_id in {db_model}")
+        if match_string_db_model.matches is None:
+            raise ScapError(f"Missing matches in {db_model}")
+
+        matches = []
+        for db_match in match_string_db_model.matches:
+            if not db_match.cpe_name_id:
+                raise ScapError(f"Missing cpe_name_id in {db_match}")
+
+            matches.append(
+                CPEMatch(
+                    cpe_name_id=UUID(str(db_match.cpe_name_id)),
+                    cpe_name=db_match.cpe_name,
+                )
+            )
+
+        return CPEMatchString(
+            match_criteria_id=UUID(
+                str(match_string_db_model.match_criteria_id)
+            ),
+            criteria=match_string_db_model.criteria,
+            status=match_string_db_model.status,
+            cpe_last_modified=match_string_db_model.cpe_last_modified,
+            created=match_string_db_model.created,
+            last_modified=match_string_db_model.last_modified,
+            matches=matches,
+            version_start_including=match_string_db_model.version_start_including,
+            version_start_excluding=match_string_db_model.version_start_excluding,
+            version_end_including=match_string_db_model.version_end_including,
+            version_end_excluding=match_string_db_model.version_end_excluding,
+        )
+
+    async def _db_item_count(self) -> int:
+        """
+        Callback getting the total number of CPE match strings in the database.
+
+        Returns:
+            The total number of CPE match strings
+        """
+        return await self._manager.count()
+
+    def _db_item_iter(self) -> AsyncIterator[BaseDatabaseModel]:
+        """
+        Callback getting an async iterator of database items to process.
+
+        Returns:
+            An async iterator over database items.
+        """
+        return self._manager.all()

--- a/greenbone/scap/cpe_match/producer/nvd_api.py
+++ b/greenbone/scap/cpe_match/producer/nvd_api.py
@@ -17,7 +17,7 @@ from greenbone.scap.generic_cli.producer.nvd_api import NvdApiProducer
 
 class CpeMatchNvdApiProducer(NvdApiProducer[CPEMatchString]):
     """
-    Abstract async context manager class for a producer querying
+    Async context manager class for a producer querying
     CPE match strings from an NVD API.
     """
 

--- a/greenbone/scap/generic_cli/producer/db.py
+++ b/greenbone/scap/generic_cli/producer/db.py
@@ -293,7 +293,8 @@ class DatabaseProducer(BaseScapProducer, Generic[T]):
                     self._progress.update(task, completed=count)
 
                 count += len(chunk)
-                await self._queue.put_chunk(chunk)
+                if len(chunk):
+                    await self._queue.put_chunk(chunk)
                 self._progress.update(task, completed=count)
 
             self._console.log(

--- a/greenbone/scap/generic_cli/producer/db.py
+++ b/greenbone/scap/generic_cli/producer/db.py
@@ -1,0 +1,316 @@
+# SPDX-FileCopyrightText: 2025 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import os
+from abc import abstractmethod
+from argparse import ArgumentParser
+from typing import (
+    AsyncContextManager,
+    AsyncIterator,
+    Generic,
+    Type,
+    TypeVar,
+)
+
+from rich.console import Console
+from rich.progress import Progress
+
+from greenbone.scap.cli import (
+    DEFAULT_POSTGRES_DATABASE_NAME,
+    DEFAULT_POSTGRES_HOST,
+    DEFAULT_POSTGRES_PORT,
+    DEFAULT_VERBOSITY,
+    CLIError,
+)
+from greenbone.scap.cpe_match.db.models import BaseDatabaseModel
+from greenbone.scap.generic_cli.producer.base import BaseScapProducer
+
+from ...db import PostgresDatabase
+from ...timer import Timer
+
+T = TypeVar("T")
+"Generic type variable for the type of SCAP items handled"
+
+
+class DatabaseProducer(BaseScapProducer, Generic[T]):
+    """
+    Abstract async context manager base class for a producer querying
+    SCAP items from a PostgreSQL database.
+
+    The type of items is to be defined by the generic type T in subclasses.
+    """
+
+    _item_type_plural = BaseScapProducer._item_type_plural
+    "Plural form of the type of items to use in log messages"
+
+    _arg_defaults = {
+        "database_name": DEFAULT_POSTGRES_DATABASE_NAME,
+        "database_host": DEFAULT_POSTGRES_HOST,
+        "database_port": DEFAULT_POSTGRES_PORT,
+        "database_schema": None,
+        "verbose": DEFAULT_VERBOSITY,
+    }
+    "Default values for optional arguments."
+
+    @classmethod
+    def add_args_to_parser(
+        cls: Type["DatabaseProducer"],
+        parser: ArgumentParser,
+    ):
+        """
+        Class method for adding database writer arguments to an
+         `ArgumentParser`.
+
+        Args:
+            parser: The parser to add the arguments to.
+        """
+        db_group = parser.add_argument_group(
+            title="Database", description="Database related settings"
+        )
+
+        db_group.add_argument(
+            "--database-name",
+            help=f"Name of the {cls._item_type_plural} database. "
+            f"Uses environment variable DATABASE_NAME or "
+            f"\"{cls._arg_defaults['database_name']}\" if not set.",
+        )
+        db_group.add_argument(
+            "--database-host",
+            help=f"Name of the {cls._item_type_plural} database host. "
+            f"Uses environment variable DATABASE_HOST or "
+            f"\"{cls._arg_defaults['database_host']}\" if not set.",
+        )
+
+        db_group.add_argument(
+            "--database-port",
+            help=f"Port for the {cls._item_type_plural} database. "
+            f"Uses environment variable DATABASE_PORT or "
+            f"{cls._arg_defaults['database_port']} if not set.",
+            type=int,
+        )
+        db_group.add_argument(
+            "--database-user",
+            help=f"Name of the {cls._item_type_plural} database user. "
+            f"Uses environment variable DATABASE_USER if not set.",
+        )
+        db_group.add_argument(
+            "--database-password",
+            help=f"Name of the {cls._item_type_plural} database password. "
+            f"Uses environment variable DATABASE_PASSWORD if not set.",
+        )
+        db_group.add_argument(
+            "--database-schema",
+            help=f"Name of the {cls._item_type_plural} database schema. "
+            f"Uses environment variable DATABASE_SCHEMA or "
+            f"\"{cls._arg_defaults['database_schema']}\" if not set.",
+        )
+        db_group.add_argument(
+            "--echo-sql",
+            action="store_true",
+            help="Print out all SQL queries.",
+        )
+
+    def __init__(
+        self,
+        console: Console,
+        error_console: Console,
+        progress: Progress,
+        *,
+        database_name: str | None,
+        database_schema: str | None,
+        database_host: str | None,
+        database_port: int | None,
+        database_user: str | None,
+        database_password: str | None,
+        echo_sql: bool = False,
+        verbose: int = _arg_defaults["verbose"],
+    ):
+        """
+        Constructor for a SCAP database write worker.
+
+        If the `database_...` arguments are None or not given, corresponding
+        environment variables will be tried next before finally using the
+        defaults as a fallback.
+
+        Args:
+            console: Console for standard output.
+            error_console: Console for error output.
+            progress: Progress bar renderer to be updated by the producer.
+            database_name: Name of the database to use.
+            database_schema: Optional database schema to use.
+            database_host: IP address or hostname of the database server to use.
+            database_port: Port of the database server to use.
+            database_user: Name of the database user to use.
+            database_password: Password of the database user to use.
+            echo_sql: Whether to print SQL statements.
+            verbose: Verbosity level of log messages.
+        """
+        super().__init__(console, error_console, progress, verbose=verbose)
+
+        database_name = (
+            database_name
+            or os.environ.get("DATABASE_NAME")
+            or self._arg_defaults["database_name"]
+        )
+        database_schema = (
+            database_schema
+            or os.environ.get("DATABASE_SCHEMA")
+            or self._arg_defaults["database_schema"]
+        )
+        database_host = (
+            database_host
+            or os.environ.get("DATABASE_HOST")
+            or self._arg_defaults["database_host"]
+        )
+        try:
+            port_str = os.environ.get("DATABASE_PORT")
+            env_database_port = int(port_str) if port_str else None
+        except TypeError:
+            env_database_port = None
+        database_port = (
+            database_port
+            or env_database_port
+            or self._arg_defaults["database_port"]
+        )
+        database_user = database_user or os.environ.get("DATABASE_USER")
+        database_password = database_password or os.environ.get(
+            "DATABASE_PASSWORD"
+        )
+
+        if not database_user:
+            raise CLIError(
+                f"Missing user for {self._item_type_plural} database"
+            )
+
+        if not database_password:
+            raise CLIError(
+                f"Missing password for {self._item_type_plural} database"
+            )
+
+        self._database = PostgresDatabase(
+            user=database_user,
+            password=database_password,
+            host=database_host,
+            port=database_port,
+            dbname=database_name,  # type: ignore
+            schema=database_schema,
+            echo=echo_sql,
+        )
+        if verbose:
+            console.log(f"Using PostgreSQL database {database_name}")
+        if verbose >= 2:
+            console.log(
+                f"Database host: {database_host}, port: {database_port}, "
+                f"schema: {database_schema}, user: {database_user}"
+            )
+
+        self._manager = self._create_manager()
+
+    @abstractmethod
+    def _create_manager(self) -> AsyncContextManager:
+        """
+        Callback creating a new database manager for handling SCAP items.
+
+        Returns: The new database manager.
+        """
+        pass
+
+    @abstractmethod
+    def _convert_db_model(self, db_model: BaseDatabaseModel) -> T:
+        """
+        Callback converting a SCAP database model to a Pontos model.
+
+        Args:
+            db_model: The database model convert
+
+        Returns:
+            The converted model object.
+        """
+        pass
+
+    @abstractmethod
+    async def _db_item_count(self) -> int:
+        """
+        Callback getting the total number of SCAP items in the database.
+
+        Returns:
+            The total number of items
+        """
+        pass
+
+    @abstractmethod
+    def _db_item_iter(self) -> AsyncIterator[BaseDatabaseModel]:
+        """
+        Callback getting an async iterator of database items to process.
+
+        Returns:
+            An async iterator over database items.
+        """
+
+    async def fetch_initial_data(self) -> int:
+        """
+        Ensures any remaining initializations of the data source are done,
+         so it can be queried for chunks of SCAP items by `run_loop`.
+        It must also return the expected total number of items that will be
+         fetched.
+
+        Returns:
+            The expected total number of items.
+        """
+        count = await self._db_item_count()
+        self._console.log(
+            f"{count:,} {self._item_type_plural} available in database"
+        )
+        return count
+
+    async def run_loop(self) -> None:
+        """
+        Run a loop fetching chunks of SCAP items and adding them to the queue.
+
+        The method must also call `set_producer_finished` before returning to signal
+        that no more chunks will be added to the queue.
+
+        It should also create a task for the `progress` object and update it
+        regularly.
+        """
+        task = self._progress.add_task(
+            f"Querying {self._item_type_plural}",
+            total=self._queue.total_items,
+        )
+        count = 0
+
+        try:
+            with Timer() as query_timer:
+                chunk = []
+                async for db_item in self._db_item_iter():
+                    item: T = self._convert_db_model(db_item)
+                    chunk.append(item)
+                    if len(chunk) >= self._queue.chunk_size:
+                        count += len(chunk)
+                        await self._queue.put_chunk(chunk)
+                        chunk = []
+                    self._progress.update(task, completed=count)
+
+                count += len(chunk)
+                await self._queue.put_chunk(chunk)
+                self._progress.update(task, completed=count)
+
+            self._console.log(
+                f"Queried {count:,} {self._item_type_plural} in "
+                f"{query_timer.elapsed_time:0.4f} seconds."
+            )
+
+        finally:
+            # signal worker that we are finished with querying the DB
+            self._queue.set_producer_finished()
+
+    async def __aenter__(self):
+        await self._database.__aenter__()
+        await self._manager.__aenter__()
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        db_ret = await self._database.__aexit__(exc_type, exc_val, exc_tb)
+        manager_ret = await self._manager.__aexit__(exc_type, exc_val, exc_tb)
+        return db_ret or manager_ret

--- a/greenbone/scap/generic_cli/queue.py
+++ b/greenbone/scap/generic_cli/queue.py
@@ -97,9 +97,15 @@ class ScapChunkQueue(Generic[T]):
 
     def set_producer_finished(self) -> None:
         """
-        Sets the "producer finished" event flag.
+        Sets the "producer finished" event flag and adds an empty chunk
+        to the queue if it is not full to unblock workers already waiting
+        to get a new chunk.
         """
         self._producer_finished_event.set()
+        try:
+            self._queue.put_nowait([])
+        except asyncio.QueueFull:
+            pass
 
     async def join(self) -> None:
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,7 @@ greenbone-cpe-download = 'greenbone.scap.cpe.cli.download:main'
 greenbone-cpe-find = 'greenbone.scap.cpe.cli.find:main'
 greenbone-cpe-match-db-download = 'greenbone.scap.cpe_match.cli.db_download:main'
 greenbone-cpe-match-json-download = 'greenbone.scap.cpe_match.cli.json_download:main'
+greenbone-cpe-match-db-to-json = 'greenbone.scap.cpe_match.cli.db_to_json:main'
 
 [tool.mypy]
 files = "greenbone"

--- a/tests/cpe_match/producer/mock_worker.py
+++ b/tests/cpe_match/producer/mock_worker.py
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: 2025 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+from typing import Sequence
+
+from pontos.nvd.models.cpe_match_string import CPEMatchString
+from rich.console import Console
+from rich.progress import Progress
+
+from greenbone.scap.generic_cli.worker.base import BaseScapWorker
+
+
+class CpeMatchMockWorker(BaseScapWorker[CPEMatchString]):
+
+    def __init__(
+        self,
+        console: Console,
+        error_console: Console,
+        progress: Progress,
+        *,
+        verbose: int | None = None,
+    ):
+        super().__init__(
+            console=console,
+            error_console=error_console,
+            progress=progress,
+            verbose=verbose,
+        )
+        self.context_entered: bool = False
+        self.context_exited: bool = False
+        self.items_received: list[CPEMatchString] = []
+        self.item_count = 0
+        self.chunk_count = 0
+
+    async def _handle_chunk(self, chunk: Sequence[CPEMatchString]) -> None:
+        self.items_received.extend(chunk)
+        self.item_count += len(chunk)
+        self.chunk_count += 1
+
+    async def __aenter__(self):
+        self.context_entered = True
+
+    async def __aexit__(self, __exc_type, __exc_value, __traceback):
+        self.context_exited = True

--- a/tests/cpe_match/producer/test_db.py
+++ b/tests/cpe_match/producer/test_db.py
@@ -1,0 +1,388 @@
+# SPDX-FileCopyrightText: 2025 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import argparse
+import asyncio
+import unittest
+from datetime import datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import UUID, uuid4
+
+from rich.console import Console
+from rich.progress import Progress
+
+from greenbone.scap.cli import DEFAULT_VERBOSITY, CLIError
+from greenbone.scap.cpe_match.cli.processor import CpeMatchProcessor
+from greenbone.scap.cpe_match.db.manager import CPEMatchStringDatabaseManager
+from greenbone.scap.cpe_match.db.models import (
+    CPEMatchDatabaseModel,
+    CPEMatchStringDatabaseModel,
+)
+from greenbone.scap.cpe_match.producer.db import CpeMatchDatabaseProducer
+from tests.cpe_match.producer.mock_worker import CpeMatchMockWorker
+from tests.cpe_match.worker.mock_producer import (
+    generate_cpe_name,
+    uuid_replace,
+    uuid_replace_str,
+)
+
+
+def parse_worker_args(raw_args):
+    parser = argparse.ArgumentParser()
+    CpeMatchProcessor.add_args_to_parser(
+        parser
+    )  # for common args like "verbose"
+
+    CpeMatchDatabaseProducer.add_args_to_parser(parser)
+    return parser.parse_args(raw_args)
+
+
+class ParseArgsTestCase(unittest.TestCase):
+    @patch(
+        "greenbone.scap.cpe_match.producer.db.CpeMatchDatabaseProducer",
+        autospec=True,
+    )
+    def test_defaults(self, mock_worker_init: MagicMock):
+        console = Console(quiet=True)
+        error_console = Console(quiet=True)
+        progress = Progress(disable=True)
+
+        args = parse_worker_args([])
+        CpeMatchDatabaseProducer.from_args(
+            args, console, error_console, progress
+        )
+
+        mock_worker_init.assert_called_once_with(
+            console=console,
+            error_console=error_console,
+            progress=progress,
+            database_name=None,
+            database_schema=None,
+            database_host=None,
+            database_port=None,
+            database_user=None,
+            database_password=None,
+            echo_sql=False,
+            verbose=DEFAULT_VERBOSITY,
+        )
+
+    @patch(
+        "greenbone.scap.cpe_match.producer.db.CpeMatchDatabaseProducer",
+        autospec=True,
+    )
+    def test_database(self, mock_worker_init: MagicMock):
+        console = Console(quiet=True)
+        error_console = Console(quiet=True)
+        progress = Progress(disable=True)
+
+        args = parse_worker_args(
+            [
+                "--database-name",
+                "test-db-name",
+                "--database-schema",
+                "test-db-schema",
+                "--database-host",
+                "test-db-host",
+                "--database-port",
+                "12345",
+                "--database-user",
+                "test-db-user",
+                "--database-password",
+                "test-db-password",
+            ]
+        )
+        CpeMatchDatabaseProducer.from_args(
+            args, console, error_console, progress
+        )
+
+        mock_worker_init.assert_called_once_with(
+            console=console,
+            error_console=error_console,
+            progress=progress,
+            database_name="test-db-name",
+            database_schema="test-db-schema",
+            database_host="test-db-host",
+            database_port=12345,
+            database_user="test-db-user",
+            database_password="test-db-password",
+            echo_sql=False,
+            verbose=DEFAULT_VERBOSITY,
+        )
+
+    @patch(
+        "greenbone.scap.cpe_match.producer.db.CpeMatchDatabaseProducer",
+        autospec=True,
+    )
+    def test_echo_sql(self, mock_worker_init: MagicMock):
+        console = Console(quiet=True)
+        error_console = Console(quiet=True)
+        progress = Progress(disable=True)
+
+        args = parse_worker_args(["--echo-sql"])
+        CpeMatchDatabaseProducer.from_args(
+            args, console, error_console, progress
+        )
+
+        mock_worker_init.assert_called_once_with(
+            console=console,
+            error_console=error_console,
+            progress=progress,
+            database_name=None,
+            database_schema=None,
+            database_host=None,
+            database_port=None,
+            database_user=None,
+            database_password=None,
+            echo_sql=True,
+            verbose=DEFAULT_VERBOSITY,
+        )
+
+
+class InitTestCase(unittest.TestCase):
+    def test_missing_user(self):
+        console = Console(quiet=True)
+        error_console = Console(quiet=True)
+        progress = Progress(disable=True)
+
+        with self.assertRaises(CLIError):
+            CpeMatchDatabaseProducer(
+                console=console,
+                error_console=error_console,
+                progress=progress,
+                database_name=None,
+                database_schema=None,
+                database_host=None,
+                database_port=None,
+                database_user=None,
+                database_password=None,
+            )
+
+    def test_missing_password(self):
+        console = Console(quiet=True)
+        error_console = Console(quiet=True)
+        progress = Progress(disable=True)
+
+        with self.assertRaises(CLIError):
+            CpeMatchDatabaseProducer(
+                console=console,
+                error_console=error_console,
+                progress=progress,
+                database_name=None,
+                database_schema=None,
+                database_host=None,
+                database_port=None,
+                database_user="db-test-user",
+                database_password=None,
+            )
+
+    @patch(
+        "greenbone.scap.generic_cli.producer.db.PostgresDatabase", autospec=True
+    )
+    def test_database_defaults(self, db_mock: MagicMock):
+        console = Console(quiet=True)
+        error_console = Console(quiet=True)
+        progress = Progress(disable=True)
+
+        CpeMatchDatabaseProducer(
+            console=console,
+            error_console=error_console,
+            progress=progress,
+            database_name=None,
+            database_schema=None,
+            database_host=None,
+            database_port=None,
+            database_user="db-test-user",
+            database_password="db-test-password",
+        )
+
+        db_mock.assert_called_with(
+            user="db-test-user",
+            password="db-test-password",
+            host="localhost",
+            port=5432,
+            dbname="scap",
+            schema=None,
+            echo=False,
+        )
+
+    @patch(
+        "greenbone.scap.generic_cli.producer.db.PostgresDatabase", autospec=True
+    )
+    def test_database_custom(self, db_mock: MagicMock):
+        console = Console(quiet=True)
+        error_console = Console(quiet=True)
+        progress = Progress(disable=True)
+
+        CpeMatchDatabaseProducer(
+            console=console,
+            error_console=error_console,
+            progress=progress,
+            database_name="db-test-name",
+            database_schema="db-test-schema",
+            database_host="db-test-host",
+            database_port=12345,
+            database_user="db-test-user",
+            database_password="db-test-password",
+        )
+
+        db_mock.assert_called_with(
+            user="db-test-user",
+            password="db-test-password",
+            host="db-test-host",
+            port=12345,
+            dbname="db-test-name",
+            schema="db-test-schema",
+            echo=False,
+        )
+
+    @patch(
+        "greenbone.scap.generic_cli.producer.db.PostgresDatabase", autospec=True
+    )
+    def test_echo_sql(self, db_mock: MagicMock):
+        console = Console()
+        error_console = Console()
+        progress = Progress()
+
+        CpeMatchDatabaseProducer(
+            console=console,
+            error_console=error_console,
+            progress=progress,
+            database_name=None,
+            database_schema=None,
+            database_host=None,
+            database_port=None,
+            database_user="db-test-user",
+            database_password="db-test-password",
+            echo_sql=True,
+        )
+
+        db_mock.assert_called_with(
+            user="db-test-user",
+            password="db-test-password",
+            host="localhost",
+            port=5432,
+            dbname="scap",
+            schema=None,
+            echo=True,
+        )
+
+
+async def async_generate_db_cpe_match_strings(
+    num_match_strings: int,
+    base_match_criteria_id: UUID,
+    base_cpe_name_id: UUID,
+):
+    for i in range(num_match_strings):
+        match_criteria_id = uuid_replace_str(base_match_criteria_id, 1, i)
+        cpe_name = generate_cpe_name(1, i)
+        cpe_name_id = uuid_replace_str(base_cpe_name_id, 1, i)
+
+        now = datetime.now()
+        new_match_model = CPEMatchDatabaseModel()
+        new_match_model.cpe_name = cpe_name
+        new_match_model.cpe_name_id = cpe_name_id
+
+        new_model = CPEMatchStringDatabaseModel()
+        new_model.match_criteria_id = match_criteria_id
+        new_model.criteria = cpe_name
+        new_model.last_modified = now
+        new_model.cpe_last_modified = now - timedelta(days=-1)
+        new_model.created = now - timedelta(days=-2)
+        new_model.status = "Active"
+        new_model.matches = [new_match_model]
+
+        yield new_model
+
+
+class ProduceTestCase(unittest.IsolatedAsyncioTestCase):
+    NUM_CHUNKS = 5
+    CHUNK_SIZE = 3
+    QUEUE_SIZE = 2
+
+    @patch(
+        "greenbone.scap.generic_cli.producer.db.PostgresDatabase", autospec=True
+    )
+    @patch.object(CPEMatchStringDatabaseManager, "count")
+    @patch.object(CPEMatchStringDatabaseManager, "all")
+    async def test_read_from_db(
+        self, all_mock: AsyncMock, count_mock: AsyncMock, db_mock: AsyncMock
+    ):
+        console = Console(quiet=True)
+        error_console = Console(quiet=True)
+        progress = Progress(disable=True)
+
+        producer = CpeMatchDatabaseProducer(
+            console=console,
+            error_console=error_console,
+            progress=progress,
+            database_name="test-db-name",
+            database_schema="test-db-name",
+            database_host="test-db-host",
+            database_port=12345,
+            database_user="test-db-user",
+            database_password="test-db-password",
+        )
+        worker = CpeMatchMockWorker(
+            console=console,
+            error_console=error_console,
+            progress=progress,
+        )
+        processor = CpeMatchProcessor(
+            console,
+            error_console,
+            producer,
+            worker,
+            queue_size=self.QUEUE_SIZE,
+            chunk_size=self.CHUNK_SIZE,
+        )
+        EXPECTED_COUNT = self.NUM_CHUNKS * self.CHUNK_SIZE
+        count_mock.return_value = EXPECTED_COUNT
+
+        base_match_criteria_id = uuid4()
+        base_cpe_name_id = uuid4()
+        all_mock.return_value = async_generate_db_cpe_match_strings(
+            EXPECTED_COUNT,
+            base_match_criteria_id,
+            base_cpe_name_id,
+        )
+
+        async with asyncio.timeout(10):
+            await processor.run()
+
+            db_mock.assert_called_once_with(
+                dbname="test-db-name",
+                schema="test-db-name",
+                host="test-db-host",
+                port=12345,
+                user="test-db-user",
+                password="test-db-password",
+                echo=False,
+            )
+
+        self.assertEqual(self.NUM_CHUNKS, worker.chunk_count)
+        self.assertEqual(EXPECTED_COUNT, worker.item_count)
+
+        for i in range(EXPECTED_COUNT):
+            expected_match_criteria_id = uuid_replace(
+                base_match_criteria_id, 1, i
+            )
+            expected_cpe_name_id = uuid_replace(base_cpe_name_id, 1, i)
+            expected_cpe_name = generate_cpe_name(1, i)
+
+            match_string = worker.items_received[i]
+            self.assertEqual(
+                expected_match_criteria_id, match_string.match_criteria_id
+            )
+            self.assertIsInstance(expected_cpe_name_id, UUID)
+            self.assertEqual(expected_cpe_name, match_string.criteria)
+            self.assertIsInstance(match_string.created, datetime)
+            self.assertIsInstance(match_string.last_modified, datetime)
+            self.assertIsInstance(match_string.cpe_last_modified, datetime)
+            self.assertEqual(
+                expected_cpe_name_id, match_string.matches[0].cpe_name_id
+            )
+            self.assertIsInstance(match_string.matches[0].cpe_name_id, UUID)
+            self.assertEqual(
+                expected_cpe_name, match_string.matches[0].cpe_name
+            )

--- a/tests/cpe_match/producer/test_db.py
+++ b/tests/cpe_match/producer/test_db.py
@@ -360,7 +360,6 @@ class ProduceTestCase(unittest.IsolatedAsyncioTestCase):
                 echo=False,
             )
 
-        self.assertEqual(self.NUM_CHUNKS, worker.chunk_count)
         self.assertEqual(EXPECTED_COUNT, worker.item_count)
 
         for i in range(EXPECTED_COUNT):


### PR DESCRIPTION
## What
The script greenbone-cpe-match-db-to-json has been added, which
creates a JSON files of all the CPE matches in the database
that was created by greenbone-cpe-match-db-download.

## Why
Downloading only the recent changes from the NVD API to the DB
and creating the full JSON from there should be faster than
downloading all the data from NVD.

## References
GEA-820

## Checklist
- [x] Tests


