### PR TITLE
Fixes for CPE match JSON

### DIFF
--- a/greenbone/scap/cpe_match/json.py
+++ b/greenbone/scap/cpe_match/json.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import gzip
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, field
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Optional, Sequence, TextIO
@@ -49,10 +49,10 @@ class MatchStringResponse:
     start_index: int
     total_results: int
     timestamp: datetime
-    match_strings: list[MatchStringItem]
 
     format: str = "NVD_CPEMatchString"
     version: str = "2.0"
+    match_strings: list[MatchStringItem] = field(default_factory=list)
 
 
 class MatchStringJsonManager(JsonManager):

--- a/greenbone/scap/data_utils/json.py
+++ b/greenbone/scap/data_utils/json.py
@@ -45,12 +45,11 @@ def convert_keys_to_camel(obj: Any) -> Any:
         for old_key in old_keys:
             v = obj[old_key]
             convert_keys_to_camel(v)
+            del obj[old_key]
             # Exclude None values
             if v is not None:
                 new_key = _snake_to_camel(old_key)
-                if new_key != old_key:
-                    obj[new_key] = v
-                    del obj[old_key]
+                obj[new_key] = v
     elif isinstance(obj, list):
         for item in obj:
             convert_keys_to_camel(item)

--- a/greenbone/scap/data_utils/json.py
+++ b/greenbone/scap/data_utils/json.py
@@ -41,7 +41,7 @@ def convert_keys_to_camel(obj: Any) -> Any:
     """
 
     if isinstance(obj, dict):
-        old_keys = set(obj.keys())
+        old_keys = list(obj.keys())
         for old_key in old_keys:
             v = obj[old_key]
             convert_keys_to_camel(v)


### PR DESCRIPTION
## What
- Null / None fields are now also removed by convert_keys_to_camel if the key remains the same.
- The dataclass and convert_keys_to_camel have been adjusted so
the match_strings should always appear last in the JSON.

## Why
- Removing the null fields reduces the file size
- Moving the keys makes the metadata fields faster to find.

## References
GEA-820

