### PR TITLE
Fix: Make cpe_last_modified optional in DB model

### DIFF
--- a/greenbone/scap/cpe_match/db/models.py
+++ b/greenbone/scap/cpe_match/db/models.py
@@ -43,7 +43,7 @@ class CPEMatchStringDatabaseModel(BaseDatabaseModel):
     )
     criteria: Mapped[str]
     status: Mapped[str]
-    cpe_last_modified: Mapped[datetime]
+    cpe_last_modified: Mapped[datetime | None]
     created: Mapped[datetime]
     last_modified: Mapped[datetime]
     version_start_including: Mapped[str | None]


### PR DESCRIPTION
## What
The cpe_last_modified field in CPE match strings can now have the value None in the database model, making it consistent with the API schema where it is optional.

## Why
This fixes SQL errors when trying to load CPE match strings where the cpe_last_modified field is missing or null.

## References
GEA-911