### PR TITLE
Fix: Use correct last_modified_end_date for CPE Matches

### DIFF
--- a/greenbone/scap/cpe_match/producer/nvd_api.py
+++ b/greenbone/scap/cpe_match/producer/nvd_api.py
@@ -136,7 +136,7 @@ class CpeMatchNvdApiProducer(NvdApiProducer[CPEMatchString]):
                 "last_modified_start_date"
             ),
             last_modified_end_date=self._request_filter_opts.get(
-                "last_modified_start_date"
+                "last_modified_end_date"
             ),
             cve_id=self._request_filter_opts.get("cve_id"),
             match_string_search=self._request_filter_opts.get(


### PR DESCRIPTION
## What
The CpeMatchNvdApiProducer now uses the correct last_modified_end_date value when getting the NVDResults.

## Why
This fixes the CLI scripts always getting 0 matches if the --since option is used.

## References
GEA-918