### PR TITLE
Record run_time before processing to avoid missing CVEs

### DIFF
--- a/greenbone/scap/cve/cli/download.py
+++ b/greenbone/scap/cve/cli/download.py
@@ -400,12 +400,15 @@ async def download(console: Console, error_console: Console):
         console, verbose=verbose, chunk_size=chunk_size, queue_size=queue_size
     )
 
+    run_time = datetime.now()
+
     with Progress(console=console) as progress:
         async with (
             cve_database,
             CVEApi(token=nvd_api_key) as api,
             CVEManager(cve_database) as cve_manager,
         ):
+
             if verbose:
                 console.log("Initialized databases.")
 
@@ -434,8 +437,6 @@ async def download(console: Console, error_console: Console):
         if run_time_file:
             if until:
                 run_time = until
-            else:
-                run_time = datetime.now()
             # ensure directories exist
             run_time_file.parent.mkdir(parents=True, exist_ok=True)
             run_time_file.write_text(


### PR DESCRIPTION
## What

This PR fixes a bug where the `run_time_file` is used to used to calculate the `last_modified_start_date`. When the `run_time` value is calculated after processing, this allows a window of time between the start of processing and the run_time recorded to file. During long processing windows such as when processing the entire NIST NVD CVE dataset (e.g., 30–40 minutes), CVEs will be submitted after processing has begun (when the API fetches the total number of records to be processed) but will not be picked up when calculating the `run_time` value only after processing is complete. These CVEs will therefore be missed on the next run since they fall before the `run_time` value stored to the `run_time_file`.

The fix moves the `run_time = datetime.now()` assignment to occur before CVE download begins and is still overwritten when `until` is provided, ensuring that all CVEs available at the time processing starts are included.

Verified by testing a full download with `run_time_file tracking` and confirming that the process completed as expected and no CVEs were skipped between runs.

## Why

If run_time is recorded too late, CVEs published during the processing window may be excluded from future runs that rely on run_time_file to define the update window. This creates a timing issue conceptually aligned with CWE-362: Race Condition, where the system checks a condition (timestamp) before using it in a context where the state may have changed.

Fixing this ensures consistent, reliable CVE ingestion — especially during long-running initial loads or delta updates. This issue is similar to a race-condition such as [CWE-367](https://cwe.mitre.org/data/definitions/367.html)

## References

[CWE-367](https://cwe.mitre.org/data/definitions/367.html) CWE-367: Time-of-check Time-of-use (TOCTOU) Race Condition: The product checks the state of a resource before using that resource, but the resource's state can change between the check and the use in a way that invalidates the results of the check. This can cause the product to perform invalid actions when the resource is in an unexpected state.

## Checklist

- [x] Verified by testing a full download with `run_time_file tracking` and confirming that the process completed as expected and no CVEs were skipped between runs.

