### PR TITLE
update the _worker progress status after processing to be more accurate

### DIFF
--- a/greenbone/scap/cve/cli/download.py
+++ b/greenbone/scap/cve/cli/download.py
@@ -183,14 +183,14 @@ class CVECli:
             try:
                 cves = await self.queue.get()
 
-                processed += len(cves)
-                progress.update(task, completed=processed)
-
                 await manager.add_cves(cves)
 
                 self.cves_to_update.update((cve.id for cve in cves))
 
                 self.queue.task_done()
+
+                processed += len(cves)
+                progress.update(task, completed=processed)
 
                 self.console.log(f"Processed {processed:,} CVEs")
             except asyncio.CancelledError as e:


### PR DESCRIPTION
## What

This PR updates the _worker progress status messaging to more accurately reflect the actual state of work being done in the console progress display. Previously, the progress message was updated before the object (e.g. a CVE item) was actually processed, which led to misleading output — the console would show a CVE as "processed" before it truly was. The fix moves the progress status update after the object has been fully processed, ensuring that the console reflects the true state of work.

## Why

When the console displays that a worker has completed a task prematurely, it can lead to confusion during debugging. For example it will look like the first item is successfully processed while in fact the first item may not be successfully processed.

<!-- Remove this section if not applicable to your changes -->

- [x] Tested functionality after making the changes


