### PR TITLE
Add a exceptions constant for api access retries

### DIFF
--- a/greenbone/scap/constants.py
+++ b/greenbone/scap/constants.py
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: 2025 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+from json import JSONDecodeError
+
+from httpx import HTTPError
+
+# Exceptions on API access to catch in order to retry these calls
+STAMINA_API_RETRY_EXCEPTIONS = (JSONDecodeError, HTTPError)

--- a/greenbone/scap/cpe/cli/download.py
+++ b/greenbone/scap/cpe/cli/download.py
@@ -9,7 +9,6 @@ from datetime import datetime
 from pathlib import Path
 from typing import Sequence
 
-import httpx
 import shtab
 import stamina
 from pontos.nvd import now
@@ -29,6 +28,7 @@ from greenbone.scap.cli import (
     CLIError,
     CLIRunner,
 )
+from greenbone.scap.constants import STAMINA_API_RETRY_EXCEPTIONS
 from greenbone.scap.cpe.manager import CPEManager
 from greenbone.scap.db import PostgresDatabase
 from greenbone.scap.timer import Timer
@@ -206,7 +206,7 @@ class CPECli:
             with Timer() as download_timer:
                 count = 0
                 async for attempt in stamina.retry_context(
-                    on=httpx.HTTPError,
+                    on=STAMINA_API_RETRY_EXCEPTIONS,
                     attempts=retry_attempts,
                     timeout=None,
                 ):
@@ -250,7 +250,7 @@ class CPECli:
         last_modified_end_date: datetime | None,
     ) -> None:
         async for attempt in stamina.retry_context(
-            on=httpx.HTTPError,
+            on=STAMINA_API_RETRY_EXCEPTIONS,
             attempts=retry_attempts,
             timeout=None,
         ):

--- a/greenbone/scap/cve/cli/download.py
+++ b/greenbone/scap/cve/cli/download.py
@@ -9,7 +9,6 @@ from datetime import datetime
 from pathlib import Path
 from typing import Sequence
 
-import httpx
 import shtab
 import stamina
 from pontos.nvd import now
@@ -29,6 +28,7 @@ from greenbone.scap.cli import (
     CLIError,
     CLIRunner,
 )
+from greenbone.scap.constants import STAMINA_API_RETRY_EXCEPTIONS
 from greenbone.scap.cve.manager import CVEManager
 from greenbone.scap.db import PostgresDatabase
 from greenbone.scap.timer import Timer
@@ -212,7 +212,7 @@ class CVECli:
             with Timer() as download_timer:
                 count = 0
                 async for attempt in stamina.retry_context(
-                    on=httpx.HTTPError,
+                    on=STAMINA_API_RETRY_EXCEPTIONS,
                     attempts=retry_attempts,
                     timeout=None,
                 ):
@@ -255,7 +255,7 @@ class CVECli:
         last_modified_end_date: datetime | None,
     ) -> None:
         async for attempt in stamina.retry_context(
-            on=httpx.HTTPError,
+            on=STAMINA_API_RETRY_EXCEPTIONS,
             attempts=retry_attempts,
             timeout=None,
         ):

--- a/greenbone/scap/generic_cli/producer/nvd_api.py
+++ b/greenbone/scap/generic_cli/producer/nvd_api.py
@@ -7,7 +7,6 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Generic, TypeVar
 
-import httpx
 import stamina
 from pontos.nvd import NVDApi, NVDResults
 from rich.console import Console
@@ -18,6 +17,7 @@ from greenbone.scap.cli import (
     DEFAULT_VERBOSITY,
 )
 
+from ...constants import STAMINA_API_RETRY_EXCEPTIONS
 from ...timer import Timer
 from .base import BaseScapProducer
 
@@ -222,7 +222,7 @@ class NvdApiProducer(BaseScapProducer, Generic[T]):
             The number of expected items.
         """
         async for attempt in stamina.retry_context(
-            on=httpx.HTTPError,
+            on=STAMINA_API_RETRY_EXCEPTIONS,
             attempts=self._retry_attempts,
             timeout=None,
         ):
@@ -275,7 +275,7 @@ class NvdApiProducer(BaseScapProducer, Generic[T]):
             with Timer() as download_timer:
                 count = 0
                 async for attempt in stamina.retry_context(
-                    on=httpx.HTTPError,
+                    on=STAMINA_API_RETRY_EXCEPTIONS,
                     attempts=self._additional_retry_attempts,
                     timeout=None,
                 ):


### PR DESCRIPTION
## What

To keep retrying these API calls until they succeed, which currently happens after ~ 1-5 tries, we need to use a tuple with the already used http error and also JSONDecodeError.

As this happens multiple times, we use a constant that can be used in multiple places.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why
We have run in problems with the application when the nvd API responds properly http wise, but delivers json that cannot be decoded properly.

<!-- Describe why are these changes necessary? -->

## References

<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [N/A] Tests
